### PR TITLE
Clean up of memory blocks on Drop.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -778,7 +778,6 @@ impl Drop for VulkanAllocator {
         // Free all remaining memory blocks
         for mem_type in self.memory_types.iter_mut() {
             for mem_block in mem_type.memory_blocks.iter_mut() {
-
                 let block = mem_block.take();
                 if let Some(block) = block {
                     block.destroy(&self.device);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -774,5 +774,16 @@ impl Drop for VulkanAllocator {
         if self.debug_settings.log_leaks_on_shutdown {
             self.report_memory_leaks(Level::Warn);
         }
+
+        // Free all remaining memory blocks
+        for mem_type in self.memory_types.iter_mut() {
+            for mem_block in mem_type.memory_blocks.iter_mut() {
+
+                let block = mem_block.take();
+                if let Some(block) = block {
+                    block.destroy(&self.device);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
There is no system for cleaning up the final memory blocks when the allocator gets dropped. This PR adds a snippet that will clean-up any remaining memory blocks when drop gets called. This should solve issue #5 