### PR TITLE
Fix to visualizer API, to not store a reference to the allocator.

### DIFF
--- a/examples/vulkan-visualization/src/main.rs
+++ b/examples/vulkan-visualization/src/main.rs
@@ -299,7 +299,7 @@ fn main() {
             })
             .collect::<Vec<_>>();
 
-        let mut visualizer = gpu_allocator::visualizer::AllocatorVisualizer::new(&allocator);
+        let mut visualizer = gpu_allocator::visualizer::AllocatorVisualizer::new();
 
         loop {
             let event = event_recv.recv().unwrap();
@@ -340,7 +340,7 @@ fn main() {
             let ui = imgui.frame();
 
             // Submit visualizer ImGui commands
-            visualizer.render(&ui);
+            visualizer.render(&allocator, &ui);
 
             // Finish ImGui Frame
             let imgui_draw_data = ui.render();

--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -43,8 +43,7 @@ impl AllocatorVisualizerBlockWindow {
         }
     }
 }
-pub struct AllocatorVisualizer<'a> {
-    allocator: &'a VulkanAllocator,
+pub struct AllocatorVisualizer {
     selected_blocks: Vec<AllocatorVisualizerBlockWindow>,
     focus: Option<usize>,
     color_scheme: ColorScheme,
@@ -239,10 +238,9 @@ fn format_memory_properties(props: vk::MemoryPropertyFlags) -> String {
     result
 }
 
-impl<'a> AllocatorVisualizer<'a> {
-    pub fn new(allocator: &'a VulkanAllocator) -> Self {
+impl AllocatorVisualizer {
+    pub fn new() -> Self {
         Self {
-            allocator,
             selected_blocks: Vec::default(),
             focus: None,
             color_scheme: ColorScheme::default(),
@@ -502,10 +500,8 @@ impl<'a> AllocatorVisualizer<'a> {
         self.focus = None;
     }
 
-    pub fn render(&mut self, ui: &imgui::Ui) {
-        let alloc = self.allocator.borrow();
-
-        self.render_main_window(ui, &alloc);
-        self.render_memory_block_windows(ui, &alloc);
+    pub fn render(&mut self, allocator: &VulkanAllocator, ui: &imgui::Ui) {
+        self.render_main_window(ui, &allocator);
+        self.render_memory_block_windows(ui, &allocator);
     }
 }

--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::new_without_default)]
+
 use crate::dedicated_block_allocator;
 use crate::free_list_allocator;
 use crate::VulkanAllocator;
@@ -5,7 +7,6 @@ use crate::*;
 
 use ash::vk;
 use imgui::*;
-use std::borrow::Borrow;
 
 // Default value for block visualizer granularity.
 const DEFAULT_BYTES_PER_UNIT: i32 = 1024;


### PR DESCRIPTION
Storing a reference to the allocator made it difficult to integrate the visualizer in more complex code bases.
This has been changed to only require a reference to the allocator during rendering.
The biggest downside of this change is that it's now up to the user to always pass the same allocator reference to the visualizer. This should not really be an issue as in probably most of the use cases the user will only have a single allocator anyway.