### PR TITLE
Disable storing stack traces by default.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ impl Default for AllocatorDebugSettings {
         Self {
             log_memory_information: false,
             log_leaks_on_shutdown: true,
-            store_stack_traces: true,
+            store_stack_traces: false,
             log_allocations: false,
             log_frees: false,
             log_stack_traces: false,


### PR DESCRIPTION
Generating a stack trace seems to be taking a very long time (1.5 ms) which is not wanted in real-time applications.
This PR changes the default behaviour to not generate any stack traces.