### PR TITLE
ci: Lint and check all features; fix breakage for "visualizer" feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --workspace --all-targets
+          args: --workspace --all-targets --all-features
 
   test:
     name: Test Suite
@@ -31,7 +31,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-targets
+          args: --workspace --all-targets --all-features
 
   fmt:
     name: Rustfmt
@@ -63,4 +63,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-targets -- -D warnings
+          args: --workspace --all-targets --all-features -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ thiserror = "1.0"
 imgui = { version = "0.6", optional = true }
 
 [dev-dependencies]
-ash-window = "0.5"
+ash-window = "0.6"
 winit = "0.23"
 
 

--- a/examples/vulkan-visualization/src/helper.rs
+++ b/examples/vulkan-visualization/src/helper.rs
@@ -1,6 +1,7 @@
 use ash::version::DeviceV1_0;
 use ash::vk;
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn record_and_submit_command_buffer<D: DeviceV1_0, F: FnOnce(&D, vk::CommandBuffer)>(
     device: &D,
     command_buffer: vk::CommandBuffer,

--- a/examples/vulkan-visualization/src/imgui_renderer.rs
+++ b/examples/vulkan-visualization/src/imgui_renderer.rs
@@ -38,6 +38,7 @@ pub struct ImGuiRenderer {
 }
 
 impl ImGuiRenderer {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         imgui: &mut imgui::Context,
         device: &ash::Device,

--- a/examples/vulkan-visualization/src/main.rs
+++ b/examples/vulkan-visualization/src/main.rs
@@ -13,7 +13,7 @@ mod imgui_renderer;
 use imgui_renderer::{handle_imgui_event, ImGuiRenderer};
 
 fn main() {
-    let entry = ash::Entry::new().unwrap();
+    let entry = unsafe { ash::Entry::new() }.unwrap();
 
     let event_loop = winit::event_loop::EventLoop::new();
 

--- a/examples/vulkan-visualization/src/main.rs
+++ b/examples/vulkan-visualization/src/main.rs
@@ -306,8 +306,8 @@ fn main() {
             handle_imgui_event(imgui.io_mut(), &window, &event);
 
             let mut should_quit = false;
-            match event {
-                winit::event::Event::WindowEvent { event, .. } => match event {
+            if let winit::event::Event::WindowEvent { event, .. } = event {
+                match event {
                     winit::event::WindowEvent::KeyboardInput { input, .. } => {
                         if let Some(winit::event::VirtualKeyCode::Escape) = input.virtual_keycode {
                             should_quit = true;
@@ -317,8 +317,7 @@ fn main() {
                         should_quit = true;
                     }
                     _ => {}
-                },
-                _ => {}
+                }
             }
 
             if should_quit {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -572,6 +572,7 @@ impl MemoryType {
 
 pub struct VulkanAllocator {
     memory_types: Vec<MemoryType>,
+    memory_heaps: Vec<vk::MemoryHeap>,
     device: ash::Device,
     buffer_image_granularity: u64,
     debug_settings: AllocatorDebugSettings,
@@ -585,6 +586,7 @@ impl VulkanAllocator {
         };
 
         let memory_types = &mem_props.memory_types[..mem_props.memory_type_count as _];
+        let memory_heaps = mem_props.memory_heaps[..mem_props.memory_heap_count as _].to_vec();
 
         if desc.debug_settings.log_memory_information {
             log!(
@@ -608,13 +610,13 @@ impl VulkanAllocator {
                     mem_type.heap_index,
                 );
             }
-            for i in 0..mem_props.memory_heap_count {
+            for (i, heap) in memory_heaps.iter().enumerate() {
                 log!(
                     Level::Debug,
                     "heap[{}] flags: 0x{:x}, size: {} MiB",
                     i,
-                    mem_props.memory_heaps[i as usize].flags.as_raw(),
-                    mem_props.memory_heaps[i as usize].size / (1024 * 1024)
+                    heap.flags.as_raw(),
+                    heap.size / (1024 * 1024)
                 );
             }
         }
@@ -656,6 +658,7 @@ impl VulkanAllocator {
 
         Self {
             memory_types,
+            memory_heaps,
             device: desc.device.clone(),
             buffer_image_granularity: granularity,
             debug_settings: desc.debug_settings,

--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -264,15 +264,14 @@ impl AllocatorVisualizer {
                     alloc.buffer_image_granularity
                 ));
 
-                let heap_count = alloc.physical_mem_props.memory_heap_count;
+                let heap_count = alloc.memory_heaps.len();
                 if CollapsingHeader::new(&ImString::new(format!(
                     "Memory Heaps ({} heaps)",
                     heap_count
                 )))
                 .build(ui)
                 {
-                    for i in 0..alloc.physical_mem_props.memory_heap_count {
-                        let heap = &alloc.physical_mem_props.memory_heaps[i as usize];
+                    for (i, heap) in alloc.memory_heaps.iter().enumerate() {
                         ui.indent();
                         if CollapsingHeader::new(&ImString::new(format!("Heap: {}", i))).build(ui) {
                             ui.indent();
@@ -316,10 +315,7 @@ impl AllocatorVisualizer {
                                 format_memory_properties(mem_type.memory_properties),
                                 mem_type.memory_properties.as_raw()
                             ));
-                            ui.text(&format!(
-                                "heap index: {}",
-                                alloc.physical_mem_props.memory_types[mem_type_i].heap_index
-                            ));
+                            ui.text(&format!("heap index: {}", mem_type.heap_index));
                             ui.text(&format!(
                                 "total block size: {} KiB",
                                 total_block_size / 1024


### PR DESCRIPTION
Not enabling this caused the visualizer feature to be completely forgotten about allowing a refactor _and_ version bump to introduce unexpected regression when the feature is enabled by crate users.
