### PR TITLE
Make docs testable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,16 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: Test all targets
+        uses: actions-rs/cargo@v1
         with:
           command: test
           args: --workspace --all-targets --all-features
+      - name: Test docs
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --doc --all-features
 
   fmt:
     name: Rustfmt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,12 @@
 //!
 //! ## Setting up the Vulkan memory allocator
 //!
-//! ```
-//! use ash::version::{DeviceV1_0, EntryV1_0, InstanceV1_0};
-//! use ash::vk;
+//! ```no_run
+//! use gpu_allocator::*;
+//! # use ash::vk;
+//! # let device = todo!();
+//! # let instance = todo!();
+//! # let physical_device = todo!();
 //!
 //! let mut allocator = VulkanAllocator::new(&VulkanAllocatorCreateDesc {
 //!     instance,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,13 +19,27 @@
 //!
 //! ## Simple Vulkan allocation example
 //!
-//! ```
+//! ```no_run
+//! use gpu_allocator::*;
+//! # use ash::vk;
+//! # use ash::version::{DeviceV1_0, EntryV1_0, InstanceV1_0};
+//! # let device = todo!();
+//! # let instance = todo!();
+//! # let physical_device = todo!();
+//!
+//! # let mut allocator = VulkanAllocator::new(&VulkanAllocatorCreateDesc {
+//! #     instance,
+//! #     device,
+//! #     physical_device,
+//! #     debug_settings: Default::default(),
+//! # });
+//!
 //! // Setup vulkan info
 //! let vk_info = vk::BufferCreateInfo::builder()
 //!     .size(512)
 //!     .usage(vk::BufferUsageFlags::STORAGE_BUFFER);
 //!
-//! let buffer = unsafe { device.create_buffer(&vk_info, None) }?;
+//! let buffer = unsafe { device.create_buffer(&vk_info, None) }.unwrap();
 //! let requirements = unsafe { device.get_buffer_memory_requirements(buffer) };
 //!
 //! let allocation = allocator
@@ -34,13 +48,13 @@
 //!         requirements,
 //!         location: MemoryLocation::CpuToGpu,
 //!         linear: true, // Buffers are always linear
-//!     })?;
+//!     }).unwrap();
 //!
 //! // Bind memory to the buffer
-//! unsafe { device.bind_buffer_memory(buffer, allocation.memory(), allocation.offset())? };
+//! unsafe { device.bind_buffer_memory(buffer, allocation.memory(), allocation.offset()).unwrap() };
 //!
 //! // Cleanup
-//! allocator.free(allocation)?;
+//! allocator.free(allocation).unwrap();
 //! unsafe { device.destroy_buffer(buffer, None) };
 //! ```
 #![deny(clippy::unimplemented, clippy::unwrap_used, clippy::ok_expect)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -572,6 +572,7 @@ impl MemoryType {
 
 pub struct VulkanAllocator {
     memory_types: Vec<MemoryType>,
+    #[cfg(feature = "visualizer")]
     memory_heaps: Vec<vk::MemoryHeap>,
     device: ash::Device,
     buffer_image_granularity: u64,
@@ -658,6 +659,7 @@ impl VulkanAllocator {
 
         Self {
             memory_types,
+            #[cfg(feature = "visualizer")]
             memory_heaps,
             device: desc.device.clone(),
             buffer_image_granularity: granularity,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Setting up the Vulkan memory allocator
 //!
-//! ```rust
+//! ```
 //! use ash::version::{DeviceV1_0, EntryV1_0, InstanceV1_0};
 //! use ash::vk;
 //!
@@ -16,7 +16,7 @@
 //!
 //! ## Simple Vulkan allocation example
 //!
-//! ```rust
+//! ```
 //! // Setup vulkan info
 //! let vk_info = vk::BufferCreateInfo::builder()
 //!     .size(512)


### PR DESCRIPTION
The docs look testable especially since they do not have an `ignore` annotation, but the opposite is true. Fix the docs so that new crate users can copypaste the code and expect it work; at the same time enforce compilability in the CI.
