### PR TITLE
Implement Send + Sync for MemoryBlock

### DIFF
--- a/examples/vulkan-buffer/src/main.rs
+++ b/examples/vulkan-buffer/src/main.rs
@@ -51,11 +51,11 @@ fn main() {
         };
         pdevices
             .iter()
-            .map(|pdevice| {
+            .find_map(|pdevice| {
                 unsafe { instance.get_physical_device_queue_family_properties(*pdevice) }
                     .iter()
                     .enumerate()
-                    .filter_map(|(index, &info)| {
+                    .find_map(|(index, &info)| {
                         let supports_graphics = info.queue_flags.contains(vk::QueueFlags::GRAPHICS);
                         if supports_graphics {
                             Some((*pdevice, index))
@@ -63,10 +63,7 @@ fn main() {
                             None
                         }
                     })
-                    .next()
             })
-            .filter_map(|v| v)
-            .next()
             .expect("Couldn't find suitable device.")
     };
 

--- a/examples/vulkan-visualization/src/imgui_renderer.rs
+++ b/examples/vulkan-visualization/src/imgui_renderer.rs
@@ -747,8 +747,8 @@ impl ImGuiRenderer {
 
             {
                 let vertices = draw_list.vtx_buffer();
-                let dst_ptr =
-                    self.vb_allocation.mapped_ptr().unwrap().as_ptr() as *mut imgui::DrawVert;
+                let dst_ptr = unsafe { self.vb_allocation.mapped_ptr() }.unwrap().as_ptr()
+                    as *mut imgui::DrawVert;
                 let dst_ptr = unsafe { dst_ptr.offset(vb_offset) };
                 unsafe {
                     std::ptr::copy_nonoverlapping(vertices.as_ptr(), dst_ptr, vertices.len())
@@ -758,8 +758,8 @@ impl ImGuiRenderer {
 
             {
                 let indices = draw_list.idx_buffer();
-                let dst_ptr =
-                    self.ib_allocation.mapped_ptr().unwrap().as_ptr() as *mut imgui::DrawIdx;
+                let dst_ptr = unsafe { self.ib_allocation.mapped_ptr() }.unwrap().as_ptr()
+                    as *mut imgui::DrawIdx;
                 let dst_ptr = unsafe { dst_ptr.offset(ib_offset) };
                 unsafe { std::ptr::copy_nonoverlapping(indices.as_ptr(), dst_ptr, indices.len()) };
                 ib_offset += indices.len() as isize;

--- a/examples/vulkan-visualization/src/imgui_renderer.rs
+++ b/examples/vulkan-visualization/src/imgui_renderer.rs
@@ -591,18 +591,16 @@ impl ImGuiRenderer {
         };
 
         Ok(Self {
+            sampler,
+
             vb_capacity,
-            vb_allocation,
-            vertex_buffer,
-
             ib_capacity,
+            vb_allocation,
             ib_allocation,
+            vertex_buffer,
             index_buffer,
-
             cb_allocation,
             constant_buffer,
-
-            sampler,
 
             font_image,
             font_image_memory,

--- a/examples/vulkan-visualization/src/imgui_renderer.rs
+++ b/examples/vulkan-visualization/src/imgui_renderer.rs
@@ -76,7 +76,7 @@ impl ImGuiRenderer {
                 .build()];
             let set_layouts = set_layout_infos
                 .iter()
-                .map(|info| Ok(unsafe { device.create_descriptor_set_layout(info, None) }?))
+                .map(|info| unsafe { device.create_descriptor_set_layout(info, None) })
                 .collect::<Result<Vec<_>, vk::Result>>()?;
 
             let layout_info = vk::PipelineLayoutCreateInfo::builder()

--- a/examples/vulkan-visualization/src/main.rs
+++ b/examples/vulkan-visualization/src/main.rs
@@ -81,11 +81,11 @@ fn main() {
             };
             pdevices
                 .iter()
-                .map(|pdevice| {
+                .find_map(|pdevice| {
                     unsafe { instance.get_physical_device_queue_family_properties(*pdevice) }
                         .iter()
                         .enumerate()
-                        .filter_map(|(index, &info)| {
+                        .find_map(|(index, &info)| {
                             let supports_graphics =
                                 info.queue_flags.contains(vk::QueueFlags::GRAPHICS);
                             let supports_surface = unsafe {
@@ -102,10 +102,7 @@ fn main() {
                                 None
                             }
                         })
-                        .next()
                 })
-                .filter_map(|v| v)
-                .next()
                 .expect("Couldn't find suitable device.")
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,31 +233,17 @@ impl SubAllocation {
     /// Returns a valid mapped slice if the memory is host visible, otherwise it will return None.
     /// The slice already references the exact memory region of the suballocation, so no offset needs to be applied.
     pub fn mapped_slice(&self) -> Option<&[u8]> {
-        if let Some(ptr) = self.mapped_ptr {
-            unsafe {
-                Some(std::slice::from_raw_parts(
-                    ptr.as_ptr() as *const _,
-                    self.size as usize,
-                ))
-            }
-        } else {
-            None
-        }
+        self.mapped_ptr.map(|ptr| unsafe {
+            std::slice::from_raw_parts(ptr.as_ptr() as *const _, self.size as usize)
+        })
     }
 
     /// Returns a valid mapped mutable slice if the memory is host visible, otherwise it will return None.
     /// The slice already references the exact memory region of the suballocation, so no offset needs to be applied.
     pub fn mapped_slice_mut(&mut self) -> Option<&mut [u8]> {
-        if let Some(ptr) = self.mapped_ptr {
-            unsafe {
-                Some(std::slice::from_raw_parts_mut(
-                    ptr.as_ptr() as *mut _,
-                    self.size as usize,
-                ))
-            }
-        } else {
-            None
-        }
+        self.mapped_ptr.map(|ptr| unsafe {
+            std::slice::from_raw_parts_mut(ptr.as_ptr() as *mut _, self.size as usize)
+        })
     }
 
     pub fn is_null(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,14 +224,16 @@ impl SubAllocation {
 
     /// Returns a valid mapped pointer if the memory is host visible, otherwise it will return None.
     /// The pointer already points to the exact memory region of the suballocation, so no offset needs to be applied.
-    pub fn mapped_ptr(&self) -> Option<std::ptr::NonNull<std::ffi::c_void>> {
+    /// # Safety
+    /// Be careful not to mutably alias with this pointer; safety cannot be guaranteed, particularly over multiple threads.
+    pub unsafe fn mapped_ptr(&self) -> Option<std::ptr::NonNull<std::ffi::c_void>> {
         self.mapped_ptr
     }
 
     /// Returns a valid mapped slice if the memory is host visible, otherwise it will return None.
     /// The slice already references the exact memory region of the suballocation, so no offset needs to be applied.
     pub fn mapped_slice(&self) -> Option<&[u8]> {
-        if let Some(ptr) = self.mapped_ptr() {
+        if let Some(ptr) = self.mapped_ptr {
             unsafe {
                 Some(std::slice::from_raw_parts(
                     ptr.as_ptr() as *const _,
@@ -246,7 +248,7 @@ impl SubAllocation {
     /// Returns a valid mapped mutable slice if the memory is host visible, otherwise it will return None.
     /// The slice already references the exact memory region of the suballocation, so no offset needs to be applied.
     pub fn mapped_slice_mut(&mut self) -> Option<&mut [u8]> {
-        if let Some(ptr) = self.mapped_ptr() {
+        if let Some(ptr) = self.mapped_ptr {
             unsafe {
                 Some(std::slice::from_raw_parts_mut(
                     ptr.as_ptr() as *mut _,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,10 @@ impl MemoryBlock {
     }
 }
 
+// The `mapped_ptr` points towards mapped memory that outlives the buffer.
+unsafe impl Send for MemoryBlock {}
+unsafe impl Sync for MemoryBlock {}
+
 #[derive(Debug)]
 struct MemoryType {
     memory_blocks: Vec<Option<MemoryBlock>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,8 @@ impl MemoryBlock {
     }
 }
 
-// The `mapped_ptr` points towards mapped memory that outlives the buffer.
+// `mapped_ptr` is safe to send or share across threads because
+// it is never exposed publicly through [`MemoryBlock`].
 unsafe impl Send for MemoryBlock {}
 unsafe impl Sync for MemoryBlock {}
 

--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -304,11 +304,9 @@ impl AllocatorVisualizer {
                         {
                             let mut total_block_size = 0;
                             let mut total_allocated = 0;
-                            for block in mem_type.memory_blocks.iter() {
-                                if let Some(block) = block {
-                                    total_block_size += block.size;
-                                    total_allocated += block.sub_allocator.allocated();
-                                }
+                            for block in mem_type.memory_blocks.iter().flatten() {
+                                total_block_size += block.size;
+                                total_allocated += block.sub_allocator.allocated();
                             }
                             ui.text(&format!(
                                 "properties: {} (0x{:x})",


### PR DESCRIPTION
An unsafe impl Send+Sync should be ok in this case as the mapped pointer's memory outlives the buffer.
Fixes #10 