### PR TITLE
impl Hash for MemoryLocation and impl Sync for SubAllocation

### DIFF
--- a/examples/vulkan-visualization/src/imgui_renderer.rs
+++ b/examples/vulkan-visualization/src/imgui_renderer.rs
@@ -76,7 +76,7 @@ impl ImGuiRenderer {
                 .build()];
             let set_layouts = set_layout_infos
                 .iter()
-                .map(|info| Ok(unsafe { device.create_descriptor_set_layout(info, None) }?))
+                .map(|info| unsafe { device.create_descriptor_set_layout(info, None) })
                 .collect::<Result<Vec<_>, vk::Result>>()?;
 
             let layout_info = vk::PipelineLayoutCreateInfo::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ pub struct SubAllocation {
 }
 
 unsafe impl Send for SubAllocation {}
+unsafe impl Sync for SubAllocation {}
 
 impl SubAllocation {
     /// Returns the `vk::DeviceMemory` object that is backing this allocation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,8 @@ pub struct SubAllocation {
     backtrace: Option<String>,
 }
 
+// `mapped_ptr` is safe to send or share across threads because
+// it is never exposed publicly through [`SubAllocation`].
 unsafe impl Send for SubAllocation {}
 unsafe impl Sync for SubAllocation {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,8 @@ impl MemoryBlock {
 
 // `mapped_ptr` is safe to send or share across threads because
 // it is never exposed publicly through [`MemoryBlock`].
-unsafe impl Send for MemoryBlock {}unsafe impl Sync for MemoryBlock {}
+unsafe impl Send for MemoryBlock {}
+unsafe impl Sync for MemoryBlock {}
 
 #[derive(Debug)]
 struct MemoryType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,9 +196,12 @@ pub struct SubAllocation {
     backtrace: Option<String>,
 }
 
-// `mapped_ptr` is safe to send or share across threads because
-// it is never exposed publicly through [`SubAllocation`].
+// Sending is fine because mapped_ptr does not change based on the thread we are in
 unsafe impl Send for SubAllocation {}
+// Sync is also okay because Sending &SubAllocation is safe: a mutable reference
+// to the data in mapped_ptr is never exposed while `self` is immutably borrowed.
+// In order to break safety guarantees, the user needs to `unsafe`ly dereference
+// `mapped_ptr` themselves.
 unsafe impl Sync for SubAllocation {}
 
 impl SubAllocation {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,10 @@ impl MemoryBlock {
     }
 }
 
+// The `mapped_ptr` points towards mapped memory that outlives the buffer.
+unsafe impl Send for MemoryBlock {}
+unsafe impl Sync for MemoryBlock {}
+
 #[derive(Debug)]
 struct MemoryType {
     memory_blocks: Vec<Option<MemoryBlock>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub struct AllocationCreateDesc<'a> {
     pub linear: bool,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum MemoryLocation {
     /// The allocated resource is stored at an unknown memory location; let the driver decide what's the best location
     Unknown,


### PR DESCRIPTION
Hash is nice for using MemoryLocation to key hashmaps and `Sync` for `SubAllocation` should be safe for the same reason it is for `MemoryBlock`