### PR TITLE
Autogenerate README based on library documentation with cargo-readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,29 @@ jobs:
         with:
           command: clippy
           args: --workspace --all-targets --all-features -- -D warnings
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Use cached cargo-readme
+        uses: actions/cache@v2
+        id: cargo-readme-cache
+        with:
+          path: ~/.cargo/bin/cargo-readme
+          key: ${{ runner.os }}-cargo-readme
+      - name: Install cargo-readme
+        if: steps.cargo-readme-cache.outputs.cache-hit != 'true'
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-readme
+      - name: Check if README.md is up-to-date
+        run: |
+          cargo readme > README.md
+          git diff --quiet || (echo '::error::Generated README is different, please regenerate with `cargo readme > README.md`'; git diff; false)

--- a/README.tpl
+++ b/README.tpl
@@ -1,4 +1,4 @@
-📒 gpu-allocator
+📒 {{crate}}
 =
 
 [![Actions Status](https://github.com/Traverse-Research/gpu-allocator/workflows/CI/badge.svg)](https://github.com/Traverse-Research/gpu-allocator/actions)
@@ -15,50 +15,7 @@
 gpu-allocator = "0.6.0"
 ```
 
-This crate provides a fully written in Rust memory allocator for Vulkan, and will provide one for DirectX 12 in the future.
-
-### Setting up the Vulkan memory allocator
-
-```rust
-use gpu_allocator::*;
-
-let mut allocator = VulkanAllocator::new(&VulkanAllocatorCreateDesc {
-    instance,
-    device,
-    physical_device,
-    debug_settings: Default::default(),
-});
-```
-
-### Simple Vulkan allocation example
-
-```rust
-use gpu_allocator::*;
-
-
-// Setup vulkan info
-let vk_info = vk::BufferCreateInfo::builder()
-    .size(512)
-    .usage(vk::BufferUsageFlags::STORAGE_BUFFER);
-
-let buffer = unsafe { device.create_buffer(&vk_info, None) }.unwrap();
-let requirements = unsafe { device.get_buffer_memory_requirements(buffer) };
-
-let allocation = allocator
-    .allocate(&AllocationCreateDesc {
-        name: "Example allocation",
-        requirements,
-        location: MemoryLocation::CpuToGpu,
-        linear: true, // Buffers are always linear
-    }).unwrap();
-
-// Bind memory to the buffer
-unsafe { device.bind_buffer_memory(buffer, allocation.memory(), allocation.offset()).unwrap() };
-
-// Cleanup
-allocator.free(allocation).unwrap();
-unsafe { device.destroy_buffer(buffer, None) };
-```
+{{readme}}
 
 ### License
 

--- a/release.toml
+++ b/release.toml
@@ -7,4 +7,5 @@ sign-tag = true
 
 pre-release-replacements = [
   {file="README.md", search="gpu-allocator = .*", replace="{{crate_name}} = \"{{version}}\""},
+  {file="README.tpl", search="gpu-allocator = .*", replace="{{crate_name}} = \"{{version}}\""},
 ]


### PR DESCRIPTION
As discussed just last week it's annoying to keep the README and library docs in sync, in particular because the code in `README.md` isn't build-tested like the module docs.  Fortunately `cargo-readme` feeds two birds with one scone: it bases (part of) `README.md` on the module documentation - which was tested with `cargo test` just prior.