### PR TITLE
Fix lifetime issues by not calling `.build()` on Vulkan builders

### DIFF
--- a/examples/vulkan-buffer/src/main.rs
+++ b/examples/vulkan-buffer/src/main.rs
@@ -76,13 +76,12 @@ fn main() {
         };
         let priorities = [1.0];
 
-        let queue_info = [vk::DeviceQueueCreateInfo::builder()
+        let queue_info = vk::DeviceQueueCreateInfo::builder()
             .queue_family_index(queue_family_index as u32)
-            .queue_priorities(&priorities)
-            .build()];
+            .queue_priorities(&priorities);
 
         let create_info = vk::DeviceCreateInfo::builder()
-            .queue_create_infos(&queue_info)
+            .queue_create_infos(std::slice::from_ref(&queue_info))
             .enabled_extension_names(&device_extension_names_raw)
             .enabled_features(&features);
 

--- a/examples/vulkan-visualization/src/helper.rs
+++ b/examples/vulkan-visualization/src/helper.rs
@@ -40,7 +40,7 @@ pub(crate) fn record_and_submit_command_buffer<D: DeviceV1_0, F: FnOnce(&D, vk::
     unsafe {
         device.queue_submit(
             submit_queue,
-            &[submit_info.build()],
+            std::slice::from_ref(&submit_info),
             command_buffer_reuse_fence,
         )
     }

--- a/examples/vulkan-visualization/src/imgui_renderer.rs
+++ b/examples/vulkan-visualization/src/imgui_renderer.rs
@@ -557,7 +557,6 @@ impl ImGuiRenderer {
 
             let image_info = vk::DescriptorImageInfo::builder()
                 .image_view(font_image_view)
-                //.sampler(imgui_renderer.sampler)
                 .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL);
             let sampled_image = vk::WriteDescriptorSet::builder()
                 .dst_set(descriptor_sets[0])

--- a/examples/vulkan-visualization/src/main.rs
+++ b/examples/vulkan-visualization/src/main.rs
@@ -115,13 +115,12 @@ fn main() {
             };
             let priorities = [1.0];
 
-            let queue_info = [vk::DeviceQueueCreateInfo::builder()
+            let queue_info = vk::DeviceQueueCreateInfo::builder()
                 .queue_family_index(queue_family_index as u32)
-                .queue_priorities(&priorities)
-                .build()];
+                .queue_priorities(&priorities);
 
             let create_info = vk::DeviceCreateInfo::builder()
-                .queue_create_infos(&queue_info)
+                .queue_create_infos(std::slice::from_ref(&queue_info))
                 .enabled_extension_names(&device_extension_names_raw)
                 .enabled_features(&features);
 
@@ -251,18 +250,18 @@ fn main() {
 
         let descriptor_pool = {
             let pool_sizes = [
-                vk::DescriptorPoolSize::builder()
-                    .ty(vk::DescriptorType::UNIFORM_BUFFER)
-                    .descriptor_count(1)
-                    .build(),
-                vk::DescriptorPoolSize::builder()
-                    .ty(vk::DescriptorType::SAMPLED_IMAGE)
-                    .descriptor_count(1)
-                    .build(),
-                vk::DescriptorPoolSize::builder()
-                    .ty(vk::DescriptorType::SAMPLER)
-                    .descriptor_count(1)
-                    .build(),
+                vk::DescriptorPoolSize {
+                    ty: vk::DescriptorType::UNIFORM_BUFFER,
+                    descriptor_count: 1,
+                },
+                vk::DescriptorPoolSize {
+                    ty: vk::DescriptorType::SAMPLED_IMAGE,
+                    descriptor_count: 1,
+                },
+                vk::DescriptorPoolSize {
+                    ty: vk::DescriptorType::SAMPLER,
+                    descriptor_count: 1,
+                },
             ];
             let create_info = vk::DescriptorPoolCreateInfo::builder()
                 .max_sets(1)
@@ -286,11 +285,10 @@ fn main() {
             .map(|&view| {
                 let create_info = vk::FramebufferCreateInfo::builder()
                     .render_pass(imgui_renderer.render_pass)
-                    .attachments(&[view])
+                    .attachments(std::slice::from_ref(&view))
                     .width(window_width)
                     .height(window_height)
-                    .layers(1)
-                    .build();
+                    .layers(1);
 
                 unsafe { device.create_framebuffer(&create_info, None) }.unwrap()
             })
@@ -361,7 +359,7 @@ fn main() {
                     );
 
                     // Transition swapchain image to present state
-                    let image_barriers = [vk::ImageMemoryBarrier::builder()
+                    let image_barriers = vk::ImageMemoryBarrier::builder()
                         .src_access_mask(
                             vk::AccessFlags::COLOR_ATTACHMENT_READ
                                 | vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
@@ -369,16 +367,13 @@ fn main() {
                         .old_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
                         .new_layout(vk::ImageLayout::PRESENT_SRC_KHR)
                         .image(present_images[present_index as usize])
-                        .subresource_range(
-                            vk::ImageSubresourceRange::builder()
-                                .aspect_mask(vk::ImageAspectFlags::COLOR)
-                                .base_mip_level(0)
-                                .level_count(vk::REMAINING_MIP_LEVELS)
-                                .base_array_layer(0)
-                                .layer_count(vk::REMAINING_ARRAY_LAYERS)
-                                .build(),
-                        )
-                        .build()];
+                        .subresource_range(vk::ImageSubresourceRange {
+                            aspect_mask: vk::ImageAspectFlags::COLOR,
+                            base_mip_level: 0,
+                            level_count: vk::REMAINING_MIP_LEVELS,
+                            base_array_layer: 0,
+                            layer_count: vk::REMAINING_ARRAY_LAYERS,
+                        });
                     unsafe {
                         device.cmd_pipeline_barrier(
                             cmd,
@@ -387,17 +382,16 @@ fn main() {
                             vk::DependencyFlags::empty(),
                             &[],
                             &[],
-                            &image_barriers,
+                            std::slice::from_ref(&image_barriers),
                         )
                     };
                 },
             );
 
             let present_create_info = vk::PresentInfoKHR::builder()
-                .wait_semaphores(&[rendering_complete_semaphore])
-                .swapchains(&[swapchain])
-                .image_indices(&[present_index])
-                .build();
+                .wait_semaphores(std::slice::from_ref(&rendering_complete_semaphore))
+                .swapchains(std::slice::from_ref(&swapchain))
+                .image_indices(std::slice::from_ref(&present_index));
 
             unsafe { swapchain_loader.queue_present(present_queue, &present_create_info) }?;
             //break;


### PR DESCRIPTION
`.build()` discards all lifetime/borrow information attached to the builder and should be used sparingly - only when a struct is generally passed by value and does not contain pointer references.

In particular local `&[single_item]` slices get dropped at the end of an expression, well before the constructed object is passed into a Vulkan function.  Fortunately creating slices on a single item is as simple as combining the borrow of that single item with a length of `1` into a fat-pointer through `std::slice::from_ref`.  When multiple items have to be passed `.build()` is best called as late as possible, in the same expression as the Vulkan call receiving the objects.

At the same time `from_ref` helps passing builders into Vulkan functions (and other builders): builders `Deref` into their Vulkan struct natrually through `std::slice::from_ref(&some_builder)`, which does not happen when the builder is moved by-value into a temporary array through `&[some_builder]`.

In places where it is hard or obnoxious to remove `.build()` - and structs do not contain pointers - the builder has been replaced with a direct struct constructor, being more concise while at the same time not demonstrating this "bad" `.build()` pattern.
