### PR TITLE
Pass chunk_id instead of SubAllocation to SubAllocator::free

### DIFF
--- a/src/dedicated_block_allocator.rs
+++ b/src/dedicated_block_allocator.rs
@@ -1,7 +1,5 @@
 #![deny(unsafe_code, clippy::unwrap_used)]
-use super::{
-    AllocationError, AllocationType, Result, SubAllocation, SubAllocator, SubAllocatorBase,
-};
+use super::{AllocationError, AllocationType, Result, SubAllocator, SubAllocatorBase};
 use log::{log, Level};
 
 #[derive(Debug)]
@@ -53,8 +51,8 @@ impl SubAllocator for DedicatedBlockAllocator {
         Ok((0, dummy_id))
     }
 
-    fn free(&mut self, sub_allocation: SubAllocation) -> Result<()> {
-        if sub_allocation.chunk_id != std::num::NonZeroU64::new(1) {
+    fn free(&mut self, chunk_id: std::num::NonZeroU64) -> Result<()> {
+        if Some(chunk_id) != std::num::NonZeroU64::new(1) {
             Err(AllocationError::Internal("Chunk ID must be 1.".into()))
         } else {
             self.allocated = 0;

--- a/src/free_list_allocator.rs
+++ b/src/free_list_allocator.rs
@@ -1,7 +1,5 @@
 #![deny(unsafe_code, clippy::unwrap_used)]
-use super::{
-    AllocationError, AllocationType, Result, SubAllocation, SubAllocator, SubAllocatorBase,
-};
+use super::{AllocationError, AllocationType, Result, SubAllocator, SubAllocatorBase};
 use log::{log, Level};
 use std::collections::{HashMap, HashSet};
 
@@ -280,11 +278,7 @@ impl SubAllocator for FreeListAllocator {
         Ok((best_offset, chunk_id))
     }
 
-    fn free(&mut self, sub_allocation: SubAllocation) -> Result<()> {
-        let chunk_id = sub_allocation
-            .chunk_id
-            .ok_or_else(|| AllocationError::Internal("Chunk ID must be a valid value.".into()))?;
-
+    fn free(&mut self, chunk_id: std::num::NonZeroU64) -> Result<()> {
         let (next_id, prev_id) = {
             let chunk = self.chunks.get_mut(&chunk_id).ok_or_else(|| {
                 AllocationError::Internal(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ trait SubAllocator: SubAllocatorBase + std::fmt::Debug {
         backtrace: Option<&str>,
     ) -> Result<(u64, std::num::NonZeroU64)>;
 
-    fn free(&mut self, sub_allocation: SubAllocation) -> Result<()>;
+    fn free(&mut self, chunk_id: std::num::NonZeroU64) -> Result<()>;
 
     fn report_memory_leaks(
         &self,
@@ -560,7 +560,10 @@ impl MemoryType {
             .as_mut()
             .ok_or_else(|| AllocationError::Internal("Memory block must be Some.".into()))?;
 
-        mem_block.sub_allocator.free(sub_allocation)?;
+        let chunk_id = sub_allocation
+            .chunk_id
+            .ok_or_else(|| AllocationError::Internal("Chunk ID must be a valid value.".into()))?;
+        mem_block.sub_allocator.free(chunk_id)?;
 
         if mem_block.sub_allocator.is_empty() {
             if mem_block.sub_allocator.supports_general_allocations() {


### PR DESCRIPTION
The allocators are responsible for the underlying allocation algorithm but have little to do with move semantics of the allocation itself, this is the responsibility of the backend-specific allcoator "wrapper" like `VulkanAllocator`.

---

@max-traverse following the conclusion we came to today, wrapped in a concise, documented PR/commit (messing up your rebase once again :grinning:).  While writing this commit message it's pretty clear we need to come up with better naming for the allocator "algorithms" versus the backend-specific talk-to-the-api allocators.
