### PR TITLE
Unmark `fn mapped_ptr()` as unsafe and clean up raw pointer casts

### DIFF
--- a/examples/vulkan-visualization/src/imgui_renderer.rs
+++ b/examples/vulkan-visualization/src/imgui_renderer.rs
@@ -333,11 +333,11 @@ impl ImGuiRenderer {
             };
 
             // Copy font data to upload buffer
+            let dst = upload_buffer_memory.mapped_ptr().unwrap().cast().as_ptr();
             unsafe {
-                let dst = upload_buffer_memory.mapped_ptr().unwrap().as_ptr();
                 std::ptr::copy_nonoverlapping(
                     font_atlas.data.as_ptr(),
-                    dst as *mut _,
+                    dst,
                     (font_atlas.width * font_atlas.height * 4) as usize,
                 );
             }
@@ -630,8 +630,8 @@ impl ImGuiRenderer {
 
             unsafe {
                 std::ptr::copy_nonoverlapping(
-                    &cbuffer_data as *const _,
-                    self.cb_allocation.mapped_ptr().unwrap().as_ptr() as *mut ImGuiCBuffer,
+                    &cbuffer_data,
+                    self.cb_allocation.mapped_ptr().unwrap().cast().as_ptr(),
                     1,
                 )
             };
@@ -730,8 +730,12 @@ impl ImGuiRenderer {
 
             {
                 let vertices = draw_list.vtx_buffer();
-                let dst_ptr = unsafe { self.vb_allocation.mapped_ptr() }.unwrap().as_ptr()
-                    as *mut imgui::DrawVert;
+                let dst_ptr = self
+                    .vb_allocation
+                    .mapped_ptr()
+                    .unwrap()
+                    .cast::<imgui::DrawVert>()
+                    .as_ptr();
                 let dst_ptr = unsafe { dst_ptr.offset(vb_offset) };
                 unsafe {
                     std::ptr::copy_nonoverlapping(vertices.as_ptr(), dst_ptr, vertices.len())
@@ -741,8 +745,12 @@ impl ImGuiRenderer {
 
             {
                 let indices = draw_list.idx_buffer();
-                let dst_ptr = unsafe { self.ib_allocation.mapped_ptr() }.unwrap().as_ptr()
-                    as *mut imgui::DrawIdx;
+                let dst_ptr = self
+                    .ib_allocation
+                    .mapped_ptr()
+                    .unwrap()
+                    .cast::<imgui::DrawIdx>()
+                    .as_ptr();
                 let dst_ptr = unsafe { dst_ptr.offset(ib_offset) };
                 unsafe { std::ptr::copy_nonoverlapping(indices.as_ptr(), dst_ptr, indices.len()) };
                 ib_offset += indices.len() as isize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,25 +230,23 @@ impl SubAllocation {
 
     /// Returns a valid mapped pointer if the memory is host visible, otherwise it will return None.
     /// The pointer already points to the exact memory region of the suballocation, so no offset needs to be applied.
-    /// # Safety
-    /// Be careful not to mutably alias with this pointer; safety cannot be guaranteed, particularly over multiple threads.
-    pub unsafe fn mapped_ptr(&self) -> Option<std::ptr::NonNull<std::ffi::c_void>> {
+    pub fn mapped_ptr(&self) -> Option<std::ptr::NonNull<std::ffi::c_void>> {
         self.mapped_ptr
     }
 
     /// Returns a valid mapped slice if the memory is host visible, otherwise it will return None.
     /// The slice already references the exact memory region of the suballocation, so no offset needs to be applied.
     pub fn mapped_slice(&self) -> Option<&[u8]> {
-        self.mapped_ptr.map(|ptr| unsafe {
-            std::slice::from_raw_parts(ptr.as_ptr() as *const _, self.size as usize)
+        self.mapped_ptr().map(|ptr| unsafe {
+            std::slice::from_raw_parts(ptr.cast().as_ptr(), self.size as usize)
         })
     }
 
     /// Returns a valid mapped mutable slice if the memory is host visible, otherwise it will return None.
     /// The slice already references the exact memory region of the suballocation, so no offset needs to be applied.
     pub fn mapped_slice_mut(&mut self) -> Option<&mut [u8]> {
-        self.mapped_ptr.map(|ptr| unsafe {
-            std::slice::from_raw_parts_mut(ptr.as_ptr() as *mut _, self.size as usize)
+        self.mapped_ptr().map(|ptr| unsafe {
+            std::slice::from_raw_parts_mut(ptr.cast().as_ptr(), self.size as usize)
         })
     }
 


### PR DESCRIPTION
Initially coming to the conclusion that `mapped_ptr()` is an `unsafe` operation in https://github.com/Traverse-Research/gpu-allocator/pull/20 due to the nature of returning a raw pointer (whose lifetime nor aliasing can be guaranteed), it has been brought to our attention that this is not inherently `unsafe` and is not marked as such in Rust's standard library either: take all the `.as_ptr()` methods as precedent.  Interacting with this pointer (dereferencing or converting back to safe Rust datastructures like slices) employs `unsafe` instead.

Note that this leaves a loophole where Rust can get safe access to uninitalized memory, which is undefined behaviour.  This will be addressed in a future changeset.
