### PR TITLE
Visualizer: Show number of blocks at the top level

### DIFF
--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -299,7 +299,7 @@ impl AllocatorVisualizer {
                 {
                     ui.indent();
                     for (mem_type_i, mem_type) in alloc.memory_types.iter().enumerate() {
-                        if CollapsingHeader::new(&ImString::new(format!("Type: {}", mem_type_i,)))
+                        if CollapsingHeader::new(&ImString::new(format!("Type: {} ({} blocks)", mem_type_i, mem_type.memory_blocks.len() )))
                             .build(ui)
                         {
                             let mut total_block_size = 0;

--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -299,8 +299,13 @@ impl AllocatorVisualizer {
                 {
                     ui.indent();
                     for (mem_type_i, mem_type) in alloc.memory_types.iter().enumerate() {
-                        if CollapsingHeader::new(&ImString::new(format!("Type: {} ({} blocks)", mem_type_i, mem_type.memory_blocks.len() )))
-                            .build(ui)
+                        if CollapsingHeader::new(&ImString::new(format!(
+                            "Type: {} ({} blocks)###Type{}",
+                            mem_type_i,
+                            mem_type.memory_blocks.len(),
+                            mem_type_i
+                        )))
+                        .build(ui)
                         {
                             let mut total_block_size = 0;
                             let mut total_allocated = 0;


### PR DESCRIPTION
Lets you waste less time expanding Types that don't have anything in them:

![image](https://user-images.githubusercontent.com/130929/121501710-c4b4b800-c9df-11eb-9b6c-c2e78f3bd3c8.png)

Alternatively I guess you could entirely hide such Types.