### PR TITLE
visualizer: Use Ash built-in bitflags string formatting

### DIFF
--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -5,7 +5,6 @@ use crate::free_list_allocator;
 use crate::VulkanAllocator;
 use crate::*;
 
-use ash::vk;
 use imgui::*;
 
 // Default value for block visualizer granularity.
@@ -195,50 +194,6 @@ impl SubAllocatorVisualizer for dedicated_block_allocator::DedicatedBlockAllocat
     }
 }
 
-fn format_heap_flags(flags: vk::MemoryHeapFlags) -> String {
-    let flag_names = ["DEVICE_LOCAL", "MULTI_INSTANCE"];
-
-    let mut result = String::new();
-    let mut mask = 0x1;
-    for flag in flag_names.iter() {
-        if (flags.as_raw() & mask) != 0 {
-            if !result.is_empty() {
-                result += " | "
-            }
-            result += flag;
-        }
-
-        mask <<= 1;
-    }
-    result
-}
-fn format_memory_properties(props: vk::MemoryPropertyFlags) -> String {
-    let flag_names = [
-        "DEVICE_LOCAL",
-        "HOST_VISIBLE",
-        "HOST_COHERENT",
-        "HOST_CACHED",
-        "LAZILY_ALLOCATED",
-        "PROTECTED",
-        "DEVICE_COHERENT",
-        "DEVICE_UNCACHED",
-    ];
-
-    let mut result = String::new();
-    let mut mask = 0x1;
-    for flag in flag_names.iter() {
-        if (props.as_raw() & mask) != 0 {
-            if !result.is_empty() {
-                result += " | "
-            }
-            result += flag;
-        }
-
-        mask <<= 1;
-    }
-    result
-}
-
 impl AllocatorVisualizer {
     pub fn new() -> Self {
         Self {
@@ -272,8 +227,8 @@ impl AllocatorVisualizer {
                         if CollapsingHeader::new(&im_str!("Heap: {}", i)).build(ui) {
                             ui.indent();
                             ui.text(&format!(
-                                "flags: {} (0x{:x})",
-                                format_heap_flags(heap.flags),
+                                "flags: {:?} (0x{:x})",
+                                heap.flags,
                                 heap.flags.as_raw()
                             ));
                             ui.text(&format!(
@@ -310,8 +265,8 @@ impl AllocatorVisualizer {
                                 total_allocated += block.sub_allocator.allocated();
                             }
                             ui.text(&format!(
-                                "properties: {} (0x{:x})",
-                                format_memory_properties(mem_type.memory_properties),
+                                "properties: {:?} (0x{:x})",
+                                mem_type.memory_properties,
                                 mem_type.memory_properties.as_raw()
                             ));
                             ui.text(&format!("heap index: {}", mem_type.heap_index));

--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -265,15 +265,11 @@ impl AllocatorVisualizer {
                 ));
 
                 let heap_count = alloc.memory_heaps.len();
-                if CollapsingHeader::new(&ImString::new(format!(
-                    "Memory Heaps ({} heaps)",
-                    heap_count
-                )))
-                .build(ui)
+                if CollapsingHeader::new(&im_str!("Memory Heaps ({} heaps)", heap_count)).build(ui)
                 {
                     for (i, heap) in alloc.memory_heaps.iter().enumerate() {
                         ui.indent();
-                        if CollapsingHeader::new(&ImString::new(format!("Heap: {}", i))).build(ui) {
+                        if CollapsingHeader::new(&im_str!("Heap: {}", i)).build(ui) {
                             ui.indent();
                             ui.text(&format!(
                                 "flags: {} (0x{:x})",
@@ -290,21 +286,21 @@ impl AllocatorVisualizer {
                     }
                 }
 
-                if CollapsingHeader::new(&ImString::new(format!(
+                if CollapsingHeader::new(&im_str!(
                     "Memory Types: ({} types)",
                     alloc.memory_types.len()
-                )))
+                ))
                 .flags(TreeNodeFlags::DEFAULT_OPEN)
                 .build(ui)
                 {
                     ui.indent();
                     for (mem_type_i, mem_type) in alloc.memory_types.iter().enumerate() {
-                        if CollapsingHeader::new(&ImString::new(format!(
+                        if CollapsingHeader::new(&im_str!(
                             "Type: {} ({} blocks)###Type{}",
                             mem_type_i,
                             mem_type.memory_blocks.len(),
                             mem_type_i
-                        )))
+                        ))
                         .build(ui)
                         {
                             let mut total_block_size = 0;
@@ -333,11 +329,12 @@ impl AllocatorVisualizer {
                             ui.text(&format!("block count: {}", active_block_count));
                             for (block_i, block) in mem_type.memory_blocks.iter().enumerate() {
                                 if let Some(block) = block {
-                                    TreeNode::new(&ImString::new(format!(
+                                    TreeNode::new(&im_str!(
                                         "Block: {}##memtype({})",
-                                        block_i, mem_type_i
-                                    )))
-                                    .label(&ImString::new(format!("Block: {}", block_i)))
+                                        block_i,
+                                        mem_type_i
+                                    ))
+                                    .label(&im_str!("Block: {}", block_i))
                                     .build(ui, || {
                                         use ash::vk::Handle;
                                         ui.indent();
@@ -358,11 +355,12 @@ impl AllocatorVisualizer {
                                         block.sub_allocator.draw_base_info(ui);
 
                                         if block.sub_allocator.supports_visualization() {
-                                            let button_name = format!(
+                                            let button_name = im_str!(
                                                 "visualize##memtype({})block({})",
-                                                mem_type_i, block_i
+                                                mem_type_i,
+                                                block_i
                                             );
-                                            if ui.small_button(&ImString::new(button_name)) {
+                                            if ui.small_button(&button_name) {
                                                 match self
                                                     .selected_blocks
                                                     .iter()
@@ -412,10 +410,11 @@ impl AllocatorVisualizer {
                 false
             };
             let mut is_open = true;
-            imgui::Window::new(&imgui::ImString::new(format!(
+            imgui::Window::new(&imgui::im_str!(
                 "Block Visualizer##memtype({})block({})",
-                window.memory_type_index, window.block_index
-            )))
+                window.memory_type_index,
+                window.block_index
+            ))
             .size([1920.0 * 0.5, 1080.0 * 0.5], imgui::Condition::FirstUseEver)
             .title_bar(true)
             .scroll_bar(true)
@@ -454,10 +453,11 @@ impl AllocatorVisualizer {
                         .max(BYTES_PER_UNIT_MIN);
 
                     // Draw the visualization in a child window.
-                    imgui::ChildWindow::new(&ImString::new(format!(
+                    imgui::ChildWindow::new(&im_str!(
                         "Visualization Sub-window##memtype({})block({})",
-                        window.memory_type_index, window.block_index
-                    )))
+                        window.memory_type_index,
+                        window.block_index
+                    ))
                     .scrollable(true)
                     .scroll_bar(true)
                     .build(ui, || {


### PR DESCRIPTION
Ash already defines a stringifyer for bitflags (see `const_debugs.rs`) that is autogenerated based on all available flags, not just what happened to be available at the time this visualizer was written.
