### PR TITLE
Change winapi dependency from git to the latest released version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ thiserror = "1.0"
 # Only needed for vulkan.
 ash = { version = "0.33", optional = true }
 # Only needed for d3d12.
-winapi = { git = "https://github.com/Traverse-Research/winapi-rs.git", rev = "b30c725", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
+winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 # Only needed for visualizer.
 imgui = { version = "0.7", optional = true }
 
 [dev-dependencies]
 ash-window = "0.7"
 winit = "0.25"
-winapi = { git = "https://github.com/Traverse-Research/winapi-rs.git", rev = "b30c725", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
+winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 widestring = "0.4.3"
 hassle-rs = "0.5.2"
 raw-window-handle = "0.3"


### PR DESCRIPTION
Winapi was set to a custom branch that adds some `d3d12` bindings for ray tracing. The `d3d12` version of `gpu-allocator` does not use any of those features, so we can simply use the latest version published on crates.io.