### PR TITLE
Disabling buffer_device_address in vulkan examples

### DIFF
--- a/examples/vulkan-buffer/src/main.rs
+++ b/examples/vulkan-buffer/src/main.rs
@@ -92,7 +92,7 @@ fn main() {
         device: device.clone(),
         physical_device: pdevice,
         debug_settings: Default::default(),
-        buffer_device_address: false, // Check for device support and enable feature accordingly
+        buffer_device_address: false,
     })
     .unwrap();
 

--- a/examples/vulkan-buffer/src/main.rs
+++ b/examples/vulkan-buffer/src/main.rs
@@ -92,7 +92,7 @@ fn main() {
         device: device.clone(),
         physical_device: pdevice,
         debug_settings: Default::default(),
-        buffer_device_address: true,
+        buffer_device_address: false, // Check for device support and enable feature accordingly
     })
     .unwrap();
 

--- a/examples/vulkan-visualization/src/main.rs
+++ b/examples/vulkan-visualization/src/main.rs
@@ -231,7 +231,7 @@ fn main() {
             device: device.clone(),
             physical_device: pdevice,
             debug_settings: AllocatorDebugSettings::default(),
-            buffer_device_address: false, // Check for device support and enable feature accordingly
+            buffer_device_address: false,
         })
         .unwrap();
 

--- a/examples/vulkan-visualization/src/main.rs
+++ b/examples/vulkan-visualization/src/main.rs
@@ -231,7 +231,7 @@ fn main() {
             device: device.clone(),
             physical_device: pdevice,
             debug_settings: AllocatorDebugSettings::default(),
-            buffer_device_address: true,
+            buffer_device_address: false, // Check for device support and enable feature accordingly
         })
         .unwrap();
 


### PR DESCRIPTION
The vulkan examples are not doing the usual checking and enabling of features, so the feature should be disabled by default.
We could do the feature checking and enabling of the feature accordingly, but I didn't want to unnecessarily complicate the example.

Thoughts?