### PR TITLE
lib: Fix mismatched type mutability in documentation example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@
 //! # let device = todo!();
 //!
 //! # let mut allocator = Allocator::new(&AllocatorCreateDesc {
-//! #     device: Dx12DevicePtr(device as *const _),
+//! #     device: Dx12DevicePtr(device as *mut _),
 //! #     debug_settings: Default::default(),
 //! # }).unwrap();
 //!


### PR DESCRIPTION
    ---- src\lib.rs - (line 93) stdout ----
    error[E0308]: mismatched types
    Error:   --> src\lib.rs:103:27
       |
    12 |     device: Dx12DevicePtr(device as *const _),
       |                           ^^^^^^^^^^^^^^^^^^ types differ in mutability
       |
       = note: expected raw pointer `*mut c_void`
                  found raw pointer `*const _`
