### PR TITLE
remove macos and ios limitation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,6 @@ pub(crate) mod allocator;
 #[cfg(feature = "visualizer")]
 pub mod visualizer;
 
-#[cfg(all(not(any(target_os = "macos", target_os = "ios")), feature = "vulkan"))]
 pub mod vulkan;
 
 #[cfg(all(windows, feature = "d3d12"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@ pub(crate) mod allocator;
 #[cfg(feature = "visualizer")]
 pub mod visualizer;
 
+#[cfg(feature = "vulkan")]
 pub mod vulkan;
 
 #[cfg(all(windows, feature = "d3d12"))]


### PR DESCRIPTION
Hi there,

Since the 0.9.0 upgrade, the use of the library is broken at least on Apple M1. It seems that a Vulkan limitation was erroneously added to these platforms. I am running my project on this branch https://github.com/periferia-labs/rivi-loader/tree/ramp using changes of this fork, and all is good again.

To my understanding, the moltenvk support is already transparent. You can see from my project that moltenvk does not need to be added to Cargo.toml either for Vulkan to work.

I am happy to give more information about my current environment if you have disparities.

Another thing is that I cannot speak for iOS nor do I have x86 mac available this week. For M1 (target_arch = "aarch64") it works fine.

Thanks!