### PR TITLE
reduce size of Allocation structs

### DIFF
--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -148,8 +148,8 @@ pub struct Allocation {
     memory_type_index: usize,
     heap: *mut d3d12::ID3D12Heap,
 
-    name: Option<String>,
-    backtrace: Option<String>,
+    name: Option<Box<str>>,
+    backtrace: Option<Box<str>>,
 }
 
 unsafe impl Send for Allocation {}
@@ -337,8 +337,8 @@ impl MemoryType {
                 memory_block_index: block_index,
                 memory_type_index: self.memory_type_index as usize,
                 heap: mem_block.heap.as_ptr(),
-                name: Some(desc.name.to_owned()),
-                backtrace: backtrace.map(|s| s.to_owned()),
+                name: Some(desc.name.into()),
+                backtrace: backtrace.map(|s| s.into()),
             });
         }
 
@@ -363,8 +363,8 @@ impl MemoryType {
                             memory_block_index: mem_block_i,
                             memory_type_index: self.memory_type_index as usize,
                             heap: mem_block.heap.as_ptr(),
-                            name: Some(desc.name.to_owned()),
-                            backtrace: backtrace.map(|s| s.to_owned()),
+                            name: Some(desc.name.into()),
+                            backtrace: backtrace.map(|s| s.into()),
                         });
                     }
                     Err(AllocationError::OutOfMemory) => {} // Block is full, continue search.
@@ -421,8 +421,8 @@ impl MemoryType {
             memory_block_index: new_block_index,
             memory_type_index: self.memory_type_index as usize,
             heap: mem_block.heap.as_ptr(),
-            name: Some(desc.name.to_owned()),
-            backtrace: backtrace.map(|s| s.to_owned()),
+            name: Some(desc.name.into()),
+            backtrace: backtrace.map(|s| s.into()),
         })
     }
 

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -43,8 +43,8 @@ pub struct Allocation {
     device_memory: vk::DeviceMemory,
     mapped_ptr: Option<std::ptr::NonNull<std::ffi::c_void>>,
 
-    name: Option<String>,
-    backtrace: Option<String>,
+    name: Option<Box<str>>,
+    backtrace: Option<Box<str>>,
 }
 
 // Sending is fine because mapped_ptr does not change based on the thread we are in
@@ -297,8 +297,8 @@ impl MemoryType {
                 memory_type_index: self.memory_type_index as usize,
                 device_memory: mem_block.device_memory,
                 mapped_ptr: std::ptr::NonNull::new(mem_block.mapped_ptr),
-                name: Some(desc.name.to_owned()),
-                backtrace: backtrace.map(|s| s.to_owned()),
+                name: Some(desc.name.into()),
+                backtrace: backtrace.map(|s| s.into()),
             });
         }
 
@@ -330,8 +330,8 @@ impl MemoryType {
                             memory_type_index: self.memory_type_index as usize,
                             device_memory: mem_block.device_memory,
                             mapped_ptr,
-                            name: Some(desc.name.to_owned()),
-                            backtrace: backtrace.map(|s| s.to_owned()),
+                            name: Some(desc.name.into()),
+                            backtrace: backtrace.map(|s| s.into()),
                         });
                     }
                     Err(err) => match err {
@@ -402,8 +402,8 @@ impl MemoryType {
             memory_type_index: self.memory_type_index as usize,
             device_memory: mem_block.device_memory,
             mapped_ptr,
-            name: Some(desc.name.to_owned()),
-            backtrace: backtrace.map(|s| s.to_owned()),
+            name: Some(desc.name.into()),
+            backtrace: backtrace.map(|s| s.into()),
         })
     }
 


### PR DESCRIPTION
This changes the name and backtraces fields on `Allocation` to be `Box<str>` instead of `String`, netting us a `mem::size_of::<Allocation>()` decrease from 104 to 88 bytes.

Same could be done on `AllocationError`, but would be an API break.