### PR TITLE
pack memory bits to reduce the size of Allocation on Vulkan

### DIFF
--- a/src/vulkan/tests.rs
+++ b/src/vulkan/tests.rs
@@ -1,0 +1,15 @@
+#[test]
+fn test_memory_packing() {
+    let bits = super::pack_memory_bits(63, 27);
+    assert_eq!(super::unpack_memory_type_index(bits), 27);
+    assert_eq!(super::unpack_memory_block_index(bits), 63);
+
+    let bits = super::pack_memory_bits(0x7ffffff, 31);
+
+    // NB: bits should be fully populated.
+    assert_eq!(bits, !0);
+
+    assert_eq!(super::unpack_memory_block_index(bits), 0x7ffffff);
+
+    assert_eq!(super::unpack_memory_type_index(bits), 31);
+}


### PR DESCRIPTION
Follow up on #70, this saves an additional 8 bytes on my 64-bit system (presumably due to improved struct packing since the change ~~only saves 6~~ 12).

See the documentation on the `memory_bits` field for rationale on why I think this is sufficient. But these assumptions might change if ever block size implementations change.