### PR TITLE
cargo: Include license files in crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ keywords = ["vulkan", "memory", "allocator"]
 documentation = "https://docs.rs/gpu-allocator/"
 
 include = [
-    "src/**",
     "Cargo.toml",
+    "LICENSE-*",
+    "src/**",
 ]
 
 [dependencies]


### PR DESCRIPTION
When explicitly specifying what files to include, cargo does not include license files [1] unless it was a custom license specified with `license-file`.

Fixes: 1c7a78f ("Add MIT and Apache 2.0 license texts (#76)")

[1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields
