### PR TITLE
ci: Include private items in the documentation build-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --no-deps --workspace --all-features
+          args: --no-deps --workspace --all-features --document-private-items
 
   readme:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Rust documentation is not only used to document the public API of a crate, but also as a convenience (ie. intellisense) to developers working on the crate-internals itself, some of which are not public.  Normally rustdoc would not build these docs but we'd still like to hold their contents to the same standards (ie. no broken links) as their public counterpart.
