### PR TITLE
🤷‍♂️ Adding an `Option<&mut bool>` argument in the allocator imgui rendering

### DIFF
--- a/examples/d3d12-visualization/src/main.rs
+++ b/examples/d3d12-visualization/src/main.rs
@@ -429,7 +429,7 @@ fn main() {
             let current_backbuffer = &backbuffers[buffer_index as usize];
 
             let ui = imgui.frame();
-            visualizer.render(&allocator, &ui);
+            visualizer.render(&allocator, &ui, None);
             let imgui_draw_data = ui.render();
 
             unsafe {

--- a/examples/vulkan-visualization/src/main.rs
+++ b/examples/vulkan-visualization/src/main.rs
@@ -351,7 +351,7 @@ fn main() -> ash::prelude::VkResult<()> {
             visualizer
                 .as_mut()
                 .unwrap()
-                .render(allocator.as_ref().unwrap(), &ui);
+                .render(allocator.as_ref().unwrap(), &ui, None);
 
             // Finish ImGui Frame
             platform.prepare_render(&ui, &window);

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -3,10 +3,7 @@
 use super::Allocator;
 use crate::visualizer::ColorScheme;
 
-use __core::ops::Deref;
 use winapi::um::d3d12::*;
-
-use imgui::*;
 
 // Default value for block visualizer granularity.
 const DEFAULT_BYTES_PER_UNIT: i32 = 1024;
@@ -90,7 +87,6 @@ impl AllocatorVisualizer {
         }
 
         window
-            .collapsed(true, Condition::FirstUseEver)
             .size([512.0, 512.0], imgui::Condition::FirstUseEver)
             .build(ui, || {
                 use imgui::*;
@@ -284,7 +280,7 @@ impl AllocatorVisualizer {
 
     pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui, opened: Option<&mut bool>) {
         let draw = if let Some(o) = opened.as_ref() {
-            *o.deref()
+            **o
         } else {
             true
         };

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -276,10 +276,10 @@ impl AllocatorVisualizer {
 
     /// Renders imgui widgets.
     /// The `Option<&mut bool>` can be used control and track changes to the opened/closed status of the widget.
-    /// Pass `None` if no control and read-back information is required. This will always render the widget.
+    /// Pass [`None`] if no control and readback information is required. This will always render the widget.
     /// When passing `Some(&mut bool)`:
-    ///  - If the bool is false, the widget won't be drawn.
-    ///  - If the bool is true the widget will be drawn and an (X) closing button will be added to the widget bar.
+    /// - If [`false`], the widget won't be drawn.
+    /// - If [`true`], the widget will be drawn and an (X) closing button will be added to the widget bar.
     pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui, opened: Option<&mut bool>) {
         if opened != Some(&mut false) {
             self.render_main_window(ui, opened, allocator);

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -3,6 +3,7 @@
 use super::Allocator;
 use crate::visualizer::ColorScheme;
 
+use __core::ops::Deref;
 use winapi::um::d3d12::*;
 
 use imgui::*;
@@ -77,9 +78,18 @@ impl AllocatorVisualizer {
         self.color_scheme = color_scheme;
     }
 
-    fn render_main_window(&mut self, ui: &imgui::Ui, active: &mut bool, alloc: &Allocator) {
-        imgui::Window::new("Allocator visualization")
-            .opened(active)
+    fn render_main_window(&mut self, ui: &imgui::Ui, opened: Option<&mut bool>, alloc: &Allocator) {
+        let mut window = imgui::Window::new("Allocator visualization");
+
+        if let Some(opened) = opened {
+            if *opened {
+                window = window.opened(opened);
+            } else {
+                return;
+            }
+        }
+
+        window
             .collapsed(true, Condition::FirstUseEver)
             .size([512.0, 512.0], imgui::Condition::FirstUseEver)
             .build(ui, || {
@@ -272,9 +282,16 @@ impl AllocatorVisualizer {
         self.focus = None;
     }
 
-    pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui, active: &mut bool) {
-        if *active {
-            self.render_main_window(ui, active, allocator);
+    pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui, opened: Option<&mut bool>) {
+        let draw = if let Some(o) = opened.as_ref() {
+            *o.deref()
+        } else {
+            true
+        };
+
+        self.render_main_window(ui, opened, allocator);
+
+        if draw {
             self.render_memory_block_windows(ui, allocator);
         }
     }

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -276,7 +276,7 @@ impl AllocatorVisualizer {
 
     /// Renders imgui widgets.
     ///
-    /// The `Option<&mut bool>` can be used control and track changes to the opened/closed status of the widget.
+    /// The [`Option<&mut bool>`] can be used control and track changes to the opened/closed status of the widget.
     /// Pass [`None`] if no control and readback information is required. This will always render the widget.
     /// When passing `Some(&mut bool)`:
     /// - If [`false`], the widget won't be drawn.

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -275,6 +275,7 @@ impl AllocatorVisualizer {
     }
 
     /// Renders imgui widgets.
+    /// 
     /// The `Option<&mut bool>` can be used control and track changes to the opened/closed status of the widget.
     /// Pass [`None`] if no control and readback information is required. This will always render the widget.
     /// When passing `Some(&mut bool)`:

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -275,7 +275,7 @@ impl AllocatorVisualizer {
     }
 
     /// Renders imgui widgets.
-    /// 
+    ///
     /// The `Option<&mut bool>` can be used control and track changes to the opened/closed status of the widget.
     /// Pass [`None`] if no control and readback information is required. This will always render the widget.
     /// When passing `Some(&mut bool)`:

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -79,11 +79,7 @@ impl AllocatorVisualizer {
         let mut window = imgui::Window::new("Allocator visualization");
 
         if let Some(opened) = opened {
-            if *opened {
-                window = window.opened(opened);
-            } else {
-                return;
-            }
+            window = window.opened(opened);
         }
 
         window
@@ -278,16 +274,15 @@ impl AllocatorVisualizer {
         self.focus = None;
     }
 
+    /// Renders imgui widgets.
+    /// The `Option<&mut bool>` can be used control and track changes to the opened/closed status of the widget.
+    /// Pass `None` if no control and read-back information is required. This will always render the widget.
+    /// When passing `Some(&mut bool)`:
+    ///  - If the bool is false, the widget won't be drawn.
+    ///  - If the bool is true the widget will be drawn and an (X) closing button will be added to the widget bar.
     pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui, opened: Option<&mut bool>) {
-        let draw = if let Some(o) = opened.as_ref() {
-            **o
-        } else {
-            true
-        };
-
-        self.render_main_window(ui, opened, allocator);
-
-        if draw {
+        if opened != Some(&mut false) {
+            self.render_main_window(ui, opened, allocator);
             self.render_memory_block_windows(ui, allocator);
         }
     }

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -77,8 +77,9 @@ impl AllocatorVisualizer {
         self.color_scheme = color_scheme;
     }
 
-    fn render_main_window(&mut self, ui: &imgui::Ui, alloc: &Allocator) {
+    fn render_main_window(&mut self, ui: &imgui::Ui, active: &mut bool, alloc: &Allocator) {
         imgui::Window::new("Allocator visualization")
+            .opened(active)
             .collapsed(true, Condition::FirstUseEver)
             .size([512.0, 512.0], imgui::Condition::FirstUseEver)
             .build(ui, || {
@@ -271,8 +272,10 @@ impl AllocatorVisualizer {
         self.focus = None;
     }
 
-    pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui) {
-        self.render_main_window(ui, allocator);
-        self.render_memory_block_windows(ui, allocator);
+    pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui, active: &mut bool) {
+        if *active {
+            self.render_main_window(ui, active, allocator);
+            self.render_memory_block_windows(ui, allocator);
+        }
     }
 }

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -45,11 +45,7 @@ impl AllocatorVisualizer {
         let mut window = imgui::Window::new("Allocator visualization");
 
         if let Some(opened) = opened {
-            if *opened {
-                window = window.opened(opened);
-            } else {
-                return;
-            }
+            window = window.opened(opened);
         }
 
         window
@@ -265,16 +261,15 @@ impl AllocatorVisualizer {
         self.focus = None;
     }
 
+    /// Renders imgui widgets.
+    /// The `Option<&mut bool>` can be used control and track changes to the opened/closed status of the widget.
+    /// Pass `None` if no control and read-back information is required. This will always render the widget.
+    /// When passing `Some(&mut bool)`:
+    ///  - If the bool is false, the widget won't be drawn.
+    ///  - If the bool is true the widget will be drawn and an (X) closing button will be added to the widget bar.
     pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui, opened: Option<&mut bool>) {
-        let draw = if let Some(o) = opened.as_ref() {
-            **o
-        } else {
-            true
-        };
-
-        self.render_main_window(ui, opened, allocator);
-
-        if draw {
+        if opened != Some(&mut false) {
+            self.render_main_window(ui, opened, allocator);
             self.render_memory_block_windows(ui, allocator);
         }
     }

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -262,7 +262,7 @@ impl AllocatorVisualizer {
     }
 
     /// Renders imgui widgets.
-    /// 
+    ///
     /// The `Option<&mut bool>` can be used control and track changes to the opened/closed status of the widget.
     /// Pass [`None`] if no control and readback information is required. This will always render the widget.
     /// When passing `Some(&mut bool)`:

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -263,7 +263,7 @@ impl AllocatorVisualizer {
 
     /// Renders imgui widgets.
     ///
-    /// The `Option<&mut bool>` can be used control and track changes to the opened/closed status of the widget.
+    /// The [`Option<&mut bool>`] can be used control and track changes to the opened/closed status of the widget.
     /// Pass [`None`] if no control and readback information is required. This will always render the widget.
     /// When passing `Some(&mut bool)`:
     /// - If [`false`], the widget won't be drawn.

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -262,11 +262,12 @@ impl AllocatorVisualizer {
     }
 
     /// Renders imgui widgets.
+    /// 
     /// The `Option<&mut bool>` can be used control and track changes to the opened/closed status of the widget.
-    /// Pass `None` if no control and read-back information is required. This will always render the widget.
+    /// Pass [`None`] if no control and readback information is required. This will always render the widget.
     /// When passing `Some(&mut bool)`:
-    ///  - If the bool is false, the widget won't be drawn.
-    ///  - If the bool is true the widget will be drawn and an (X) closing button will be added to the widget bar.
+    /// - If [`false`], the widget won't be drawn.
+    /// - If [`true`], the widget will be drawn and an (X) closing button will be added to the widget bar.
     pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui, opened: Option<&mut bool>) {
         if opened != Some(&mut false) {
             self.render_main_window(ui, opened, allocator);

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -3,6 +3,7 @@
 use super::Allocator;
 use crate::visualizer::ColorScheme;
 
+use __core::ops::Deref;
 use imgui::*;
 
 // Default value for block visualizer granularity.
@@ -43,9 +44,18 @@ impl AllocatorVisualizer {
         self.color_scheme = color_scheme;
     }
 
-    fn render_main_window(&mut self, ui: &imgui::Ui, active: &mut bool, alloc: &Allocator) {
-        imgui::Window::new("Allocator visualization")
-            .opened(active)
+    fn render_main_window(&mut self, ui: &imgui::Ui, opened: Option<&mut bool>, alloc: &Allocator) {
+        let mut window = imgui::Window::new("Allocator visualization");
+
+        if let Some(opened) = opened {
+            if *opened {
+                window = window.opened(opened);
+            } else {
+                return;
+            }
+        }
+
+        window
             .collapsed(true, Condition::FirstUseEver)
             .size([512.0, 512.0], imgui::Condition::FirstUseEver)
             .build(ui, || {
@@ -259,9 +269,16 @@ impl AllocatorVisualizer {
         self.focus = None;
     }
 
-    pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui, active: &mut bool) {
-        if *active {
-            self.render_main_window(ui, active, allocator);
+    pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui, opened: Option<&mut bool>) {
+        let draw = if let Some(o) = opened.as_ref() {
+            *o.deref()
+        } else {
+            true
+        };
+
+        self.render_main_window(ui, opened, allocator);
+
+        if draw {
             self.render_memory_block_windows(ui, allocator);
         }
     }

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -43,8 +43,9 @@ impl AllocatorVisualizer {
         self.color_scheme = color_scheme;
     }
 
-    fn render_main_window(&mut self, ui: &imgui::Ui, alloc: &Allocator) {
+    fn render_main_window(&mut self, ui: &imgui::Ui, active: &mut bool, alloc: &Allocator) {
         imgui::Window::new("Allocator visualization")
+            .opened(active)
             .collapsed(true, Condition::FirstUseEver)
             .size([512.0, 512.0], imgui::Condition::FirstUseEver)
             .build(ui, || {
@@ -258,8 +259,10 @@ impl AllocatorVisualizer {
         self.focus = None;
     }
 
-    pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui) {
-        self.render_main_window(ui, allocator);
-        self.render_memory_block_windows(ui, allocator);
+    pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui, active: &mut bool) {
+        if *active {
+            self.render_main_window(ui, active, allocator);
+            self.render_memory_block_windows(ui, allocator);
+        }
     }
 }

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -3,9 +3,6 @@
 use super::Allocator;
 use crate::visualizer::ColorScheme;
 
-use __core::ops::Deref;
-use imgui::*;
-
 // Default value for block visualizer granularity.
 const DEFAULT_BYTES_PER_UNIT: i32 = 1024;
 
@@ -56,7 +53,6 @@ impl AllocatorVisualizer {
         }
 
         window
-            .collapsed(true, Condition::FirstUseEver)
             .size([512.0, 512.0], imgui::Condition::FirstUseEver)
             .build(ui, || {
                 use imgui::*;
@@ -271,7 +267,7 @@ impl AllocatorVisualizer {
 
     pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui, opened: Option<&mut bool>) {
         let draw = if let Some(o) = opened.as_ref() {
-            *o.deref()
+            **o
         } else {
             true
         };


### PR DESCRIPTION
This allows calling code to do the following:

- Pass None to just render the editor as usual
- Pass Some(&mut bool) to control if the window is rendered and get information in return regarding a request for closure of the window (user clicks X button on the imgui window).
This allows for easier integration with UI systems.

I had conversations with @MarijnS95 about this and we're still not 100% happy with the code, adding the draft PR because I need to reference it in another project :P 