### PR TITLE
Upgrade to ash 0.34 with ash-window 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ include = [
 backtrace = "0.3"
 log = "0.4"
 thiserror = "1.0"
-# Only needed for vulkan.
-ash = { version = "0.33", optional = true }
+# Only needed for vulkan. Disable the default "linked" feature to prevent forcibly
+# dynamic-linking against a Vulkan library on the system.  This linking, and loading
+# an entrypoint for it is only needed by the examples.
+ash = { version = "0.34", optional = true, default-features = false, features = ["debug"] }
 # Only needed for d3d12.
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 # Only needed for visualizer.
@@ -30,7 +32,7 @@ imgui = { version = "0.8", optional = true }
 imgui-winit-support = { version = "0.8", optional = true }
 
 [dev-dependencies]
-ash-window = "0.7"
+ash-window = "0.8"
 raw-window-handle = "0.3"
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 winit = "0.25"
@@ -38,12 +40,12 @@ winit = "0.25"
 [[example]]
 name = "vulkan-buffer"
 path = "examples/vulkan-buffer/src/main.rs"
-required-features = ["vulkan"]
+required-features = ["vulkan", "ash/linked"]
 
 [[example]]
 name = "vulkan-visualization"
 path = "examples/vulkan-visualization/src/main.rs"
-required-features = ["vulkan", "visualizer"]
+required-features = ["vulkan", "ash/linked", "visualizer"]
 
 [[example]]
 name = "d3d12-buffer"

--- a/examples/vulkan-buffer/src/main.rs
+++ b/examples/vulkan-buffer/src/main.rs
@@ -7,7 +7,7 @@ use gpu_allocator::vulkan::{AllocationCreateDesc, Allocator, AllocatorCreateDesc
 use gpu_allocator::MemoryLocation;
 
 fn main() {
-    let entry = unsafe { ash::Entry::new() }.unwrap();
+    let entry = ash::Entry::new();
 
     // Create vulkan instance
     let instance = {

--- a/examples/vulkan-visualization/src/imgui_renderer.rs
+++ b/examples/vulkan-visualization/src/imgui_renderer.rs
@@ -215,7 +215,10 @@ impl ImGuiRenderer {
                 .src_alpha_blend_factor(vk::BlendFactor::ZERO)
                 .dst_alpha_blend_factor(vk::BlendFactor::ZERO)
                 .alpha_blend_op(vk::BlendOp::ADD)
-                .color_write_mask(vk::ColorComponentFlags::all());
+                .color_write_mask({
+                    use vk::ColorComponentFlags::*;
+                    R | G | B | A
+                });
             let color_blend_state = vk::PipelineColorBlendStateCreateInfo::builder()
                 .logic_op(vk::LogicOp::CLEAR)
                 .attachments(std::slice::from_ref(&attachments));

--- a/examples/vulkan-visualization/src/main.rs
+++ b/examples/vulkan-visualization/src/main.rs
@@ -14,7 +14,7 @@ use imgui_renderer::ImGuiRenderer;
 use imgui_winit_support::{HiDpiMode, WinitPlatform};
 
 fn main() -> ash::prelude::VkResult<()> {
-    let entry = unsafe { ash::Entry::new() }.unwrap();
+    let entry = ash::Entry::new();
 
     let event_loop = winit::event_loop::EventLoop::new();
 


### PR DESCRIPTION
This ash release switches over to a dynamically linked scheme where Vulkan is linked directly instead of through libloading by default.  As the main library crate doesn't need to load an entrypoint such linking is not desired at all and is disabled by default (as is runtime linking, effectively no entrypoints can be loaded): it must be re-enabled by hand when building the examples.
