### PR TITLE
vulkan: Remove unused `backtrace` field from `Allocator`

### DIFF
--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -149,7 +149,6 @@ pub struct Allocation {
     heap: *mut d3d12::ID3D12Heap,
 
     name: Option<Box<str>>,
-    backtrace: Option<Box<str>>,
 }
 
 unsafe impl Send for Allocation {}
@@ -197,7 +196,6 @@ impl Default for Allocation {
             memory_type_index: !0,
             heap: std::ptr::null_mut(),
             name: None,
-            backtrace: None,
         }
     }
 }
@@ -369,7 +367,6 @@ impl MemoryType {
                 memory_type_index: self.memory_type_index as usize,
                 heap: mem_block.heap.as_ptr(),
                 name: Some(desc.name.into()),
-                backtrace: backtrace.map(|s| s.into()),
             });
         }
 
@@ -395,7 +392,6 @@ impl MemoryType {
                             memory_type_index: self.memory_type_index as usize,
                             heap: mem_block.heap.as_ptr(),
                             name: Some(desc.name.into()),
-                            backtrace: backtrace.map(|s| s.into()),
                         });
                     }
                     Err(AllocationError::OutOfMemory) => {} // Block is full, continue search.
@@ -453,7 +449,6 @@ impl MemoryType {
             memory_type_index: self.memory_type_index as usize,
             heap: mem_block.heap.as_ptr(),
             name: Some(desc.name.into()),
-            backtrace: backtrace.map(|s| s.into()),
         })
     }
 

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -44,7 +44,6 @@ pub struct Allocation {
     mapped_ptr: Option<std::ptr::NonNull<std::ffi::c_void>>,
 
     name: Option<Box<str>>,
-    backtrace: Option<Box<str>>,
 }
 
 // Sending is fine because mapped_ptr does not change based on the thread we are in
@@ -121,7 +120,6 @@ impl Default for Allocation {
             device_memory: vk::DeviceMemory::null(),
             mapped_ptr: None,
             name: None,
-            backtrace: None,
         }
     }
 }
@@ -298,7 +296,6 @@ impl MemoryType {
                 device_memory: mem_block.device_memory,
                 mapped_ptr: std::ptr::NonNull::new(mem_block.mapped_ptr),
                 name: Some(desc.name.into()),
-                backtrace: backtrace.map(|s| s.into()),
             });
         }
 
@@ -331,7 +328,6 @@ impl MemoryType {
                             device_memory: mem_block.device_memory,
                             mapped_ptr,
                             name: Some(desc.name.into()),
-                            backtrace: backtrace.map(|s| s.into()),
                         });
                     }
                     Err(err) => match err {
@@ -403,7 +399,6 @@ impl MemoryType {
             device_memory: mem_block.device_memory,
             mapped_ptr,
             name: Some(desc.name.into()),
-            backtrace: backtrace.map(|s| s.into()),
         })
     }
 


### PR DESCRIPTION
Only `SubAllocator`s print their backtrace and need to hold on to this field; there is no need for the `Allocator` to hold on to and own the exact same value.

Rust 1.57 now detects such unused fields, when they have previously only been used inside `derive()` macros such as `Debug`.
