### PR TITLE
Depend on Windows crates only on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,21 +24,25 @@ thiserror = "1.0"
 # Only needed for vulkan.  Disable all default features as good practice,
 # such as the ability to link/load a Vulkan library.
 ash = { version = "0.35", optional = true, default-features = false, features = ["debug"] }
-# Only needed for d3d12.
-winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 # Only needed for visualizer.
 imgui = { version = "0.8", optional = true }
 imgui-winit-support = { version = "0.8", optional = true, default-features = false, features = ["winit-26"] }
+
+[target.'cfg(windows)'.dependencies]
+# Only needed for d3d12.
+winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [dev-dependencies]
 # Enable the "loaded" feature to be able to access the Vulkan entrypoint.
 ash = { version = "0.35", default-features = false, features = ["debug", "loaded"] }
 ash-window = "0.9"
 raw-window-handle = "0.4"
-winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 winit = "0.26"
 
-[dev-dependencies.windows]
+[target.'cfg(windows)'.dev-dependencies]
+winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
+
+[target.'cfg(windows)'.dev-dependencies.windows]
 version = "0.29"
 features = [
     "Win32_Foundation",


### PR DESCRIPTION
Avoids downloading and depending on the Windows crates when building of other platforms, without impacting Windows support. 

Noticed that `gpu-allocator` was the only dependency that we had that brought in `winapi` when building our codebase for Mac and Linux, and including it in our licensing summaries and such. This fixes that.