### PR TITLE
Move imgui-winit-support to dev-dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ thiserror = "1.0"
 ash = { version = "0.35", optional = true, default-features = false, features = ["debug"] }
 # Only needed for visualizer.
 imgui = { version = "0.8", optional = true }
-imgui-winit-support = { version = "0.8", optional = true, default-features = false, features = ["winit-26"] }
 
 [target.'cfg(windows)'.dependencies]
 # Only needed for d3d12.
@@ -38,6 +37,7 @@ ash = { version = "0.35", default-features = false, features = ["debug", "loaded
 ash-window = "0.9"
 raw-window-handle = "0.4"
 winit = "0.26"
+imgui-winit-support = { version = "0.8", default-features = false, features = ["winit-26"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
@@ -80,7 +80,7 @@ required-features = ["d3d12", "public-winapi", "visualizer"]
 
 
 [features]
-visualizer = ["imgui", "imgui-winit-support"]
+visualizer = ["imgui"]
 vulkan = ["ash"]
 d3d12 = ["winapi"]
 public-winapi = ["winapi"]


### PR DESCRIPTION
For some reason `imgui-winit-support` was part of the regular dependencies when the `visualizer` was enabled. However, this crate is only used in the example projects, so it should be part of the `dev-dependencies`.