### PR TITLE
Allocation was incorrectly marked as Clone

### DIFF
--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -159,7 +159,7 @@ pub struct AllocatorCreateDesc {
     pub debug_settings: AllocatorDebugSettings,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Allocation {
     chunk_id: Option<std::num::NonZeroU64>,
     offset: u64,

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -33,7 +33,7 @@ pub struct AllocatorCreateDesc {
     pub buffer_device_address: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Allocation {
     chunk_id: Option<std::num::NonZeroU64>,
     offset: u64,


### PR DESCRIPTION
Fixes #97

> I'm pretty sure that the implementation of Clone for Allocation is unsafe, because you can clone it and call mapped_slice_mut on both, getting two &muts that alias.

This is entirely correct, so we're removing the `Clone` derives for `Allocation`.