### PR TITLE
cargo: Support `ash 0.34` all the way up to `ash 0.37`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4"
 thiserror = "1.0"
 # Only needed for vulkan.  Disable all default features as good practice,
 # such as the ability to link/load a Vulkan library.
-ash = { version = "0.36", optional = true, default-features = false, features = ["debug"] }
+ash = { version = ">=0.34, <=0.37", optional = true, default-features = false, features = ["debug"] }
 # Only needed for visualizer.
 imgui = { version = "0.8", optional = true }
 
@@ -33,8 +33,8 @@ winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "
 
 [dev-dependencies]
 # Enable the "loaded" feature to be able to access the Vulkan entrypoint.
-ash = { version = "0.36", default-features = false, features = ["debug", "loaded"] }
-ash-window = "0.9.1"
+ash = { version = "0.37", default-features = false, features = ["debug", "loaded"] }
+ash-window = "0.10.0"
 raw-window-handle = "0.4"
 winit = "0.26"
 imgui-winit-support = { version = "0.8", default-features = false, features = ["winit-26"] }

--- a/examples/vulkan-visualization/main.rs
+++ b/examples/vulkan-visualization/main.rs
@@ -48,15 +48,11 @@ fn main() -> ash::prelude::VkResult<()> {
             .collect();
 
         let surface_extensions = ash_window::enumerate_required_extensions(&window).unwrap();
-        let extensions_names_raw = surface_extensions
-            .iter()
-            .map(|ext| ext.as_ptr())
-            .collect::<Vec<_>>();
 
         let create_info = vk::InstanceCreateInfo::builder()
             .application_info(&appinfo)
             .enabled_layer_names(&layers_names_raw)
-            .enabled_extension_names(&extensions_names_raw);
+            .enabled_extension_names(surface_extensions);
 
         unsafe {
             entry

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -64,8 +64,8 @@ impl Allocation {
     /// without this library, because that will lead to undefined behavior.
     ///
     /// # Safety
-    /// The result of this function can safely be used to pass into [`vk::DeviceFnV1_0::bind_buffer_memory()`],
-    /// [`vk::DeviceFnV1_0::bind_image_memory()`] etc. It is exposed for this reason. Keep in mind to also
+    /// The result of this function can safely be used to pass into [`ash::Device::bind_buffer_memory()`],
+    /// [`ash::Device::bind_image_memory()`] etc. It is exposed for this reason. Keep in mind to also
     /// pass [`Self::offset()`] along to those.
     pub unsafe fn memory(&self) -> vk::DeviceMemory {
         self.device_memory


### PR DESCRIPTION
Using a ranged semver here allows us to publish non-breaking patch releases whenever bumping to a new - compatible! - `ash` release.  The upper bound serves to protect against breaking `ash` changes that may make this crate fail to compile, and is easy to bump whenever we've validated the next version to be compatible.

Note that the examples are updated to use the latest `ash 0.37` and `ash-window 0.10.0`, containing breaking improvements around returning raw pointers to required extension string literals instead of `CStr` static borrows.