### PR TITLE
release: Replace deprecated `no-dev-version` inversion with `dev-version=false`

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,5 +1,5 @@
 pre-release-commit-message = "Release {{version}}"
-no-dev-version = true
+dev-version = false
 tag-message = "Release {{version}}"
 tag-name = "{{version}}"
 sign-commit = true


### PR DESCRIPTION
https://github.com/crate-ci/cargo-release/blob/master/CHANGELOG.md#0190---2022-01-07
