### PR TITLE
cargo: Include examples folder in release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ keywords = ["vulkan", "memory", "allocator"]
 documentation = "https://docs.rs/gpu-allocator/"
 
 include = [
-    "Cargo.toml",
-    "LICENSE-*",
-    "src/**",
+    "/README.md",
+    "/LICENSE-*",
+    "/src",
+    "/examples",
 ]
 
 [dependencies]


### PR DESCRIPTION
Otherwise the crate cannot be published, due to the `[[examples]]` array in `Cargo.toml` not finding the required files.

Strangely enough this wasn't a problem before 7a5ad82 ("Simplify example folder structure (#106)") where this crate still used an explicit `path =` for every example, as every example seems to have been [omitted from Cargo.toml].

[omitted from Cargo.toml]: https://docs.rs/crate/gpu-allocator/0.17.0/source/Cargo.toml
