### PR TITLE
cargo: Bump windows-rs to 0.42

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ imgui = { version = "0.8", features = ["tables-api"], optional = true }
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.37"
+version = "0.38"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",
@@ -56,7 +56,7 @@ imgui-winit-support = { version = "0.8", default-features = false, features = ["
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows]
-version = "0.37"
+version = "0.38"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ imgui = { version = "0.8", features = ["tables-api"], optional = true }
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.41"
+version = "0.42"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",
@@ -56,7 +56,7 @@ imgui-winit-support = { version = "0.8", default-features = false, features = ["
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows]
-version = "0.41"
+version = "0.42"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ imgui = { version = "0.8", features = ["tables-api"], optional = true }
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.36"
+version = "0.37"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",
@@ -56,7 +56,7 @@ imgui-winit-support = { version = "0.8", default-features = false, features = ["
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows]
-version = "0.36"
+version = "0.37"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ imgui = { version = "0.8", features = ["tables-api"], optional = true }
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.38"
+version = "0.39"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",
@@ -56,7 +56,7 @@ imgui-winit-support = { version = "0.8", default-features = false, features = ["
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows]
-version = "0.38"
+version = "0.39"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ imgui = { version = "0.8", features = ["tables-api"], optional = true }
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.39"
+version = "0.40"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",
@@ -56,7 +56,7 @@ imgui-winit-support = { version = "0.8", default-features = false, features = ["
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows]
-version = "0.39"
+version = "0.40"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ imgui = { version = "0.8", features = ["tables-api"], optional = true }
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.40"
+version = "0.41"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",
@@ -56,7 +56,7 @@ imgui-winit-support = { version = "0.8", default-features = false, features = ["
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows]
-version = "0.40"
+version = "0.41"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ let hr = unsafe {
         allocation.offset(),
         &buffer_desc,
         Direct3D12::D3D12_RESOURCE_STATE_COMMON,
-        std::ptr::null(),
+        None,
         &mut resource,
     )
 }?;

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-📒 gpu-allocator
-=
+# 📒 gpu-allocator
 
-[![Actions Status](https://github.com/Traverse-Research/gpu-allocator/workflows/CI/badge.svg)](https://github.com/Traverse-Research/gpu-allocator/actions)
-[![Latest version](https://img.shields.io/crates/v/gpu-allocator.svg)](https://crates.io/crates/gpu-allocator)
-[![Docs](https://docs.rs/gpu-allocator/badge.svg)](https://docs.rs/gpu-allocator/)
+
+[![Actions Status](https://img.shields.io/github/workflow/status/Traverse-Research/gpu-allocator/CI?logo=github)](https://github.com/Traverse-Research/gpu-allocator/actions)
+[![Latest version](https://img.shields.io/crates/v/gpu-allocator.svg?logo=rust)](https://crates.io/crates/gpu-allocator)
+[![Docs](https://img.shields.io/docsrs/gpu-allocator?logo=docs.rs)](https://docs.rs/gpu-allocator/)
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
-[![LICENSE](https://img.shields.io/badge/license-apache-blue.svg)](LICENSE-APACHE)
+[![LICENSE](https://img.shields.io/badge/license-apache-blue.svg?logo=apache)](LICENSE-APACHE)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](../main/CODE_OF_CONDUCT.md)
 
 [![Banner](banner.png)](https://traverseresearch.nl)

--- a/README.tpl
+++ b/README.tpl
@@ -1,11 +1,11 @@
-📒 {{crate}}
-=
+# 📒 gpu-allocator
 
-[![Actions Status](https://github.com/Traverse-Research/gpu-allocator/workflows/CI/badge.svg)](https://github.com/Traverse-Research/gpu-allocator/actions)
-[![Latest version](https://img.shields.io/crates/v/gpu-allocator.svg)](https://crates.io/crates/gpu-allocator)
-[![Docs](https://docs.rs/gpu-allocator/badge.svg)](https://docs.rs/gpu-allocator/)
+
+[![Actions Status](https://img.shields.io/github/workflow/status/Traverse-Research/gpu-allocator/CI?logo=github)](https://github.com/Traverse-Research/gpu-allocator/actions)
+[![Latest version](https://img.shields.io/crates/v/gpu-allocator.svg?logo=rust)](https://crates.io/crates/gpu-allocator)
+[![Docs](https://img.shields.io/docsrs/gpu-allocator?logo=docs.rs)](https://docs.rs/gpu-allocator/)
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
-[![LICENSE](https://img.shields.io/badge/license-apache-blue.svg)](LICENSE-APACHE)
+[![LICENSE](https://img.shields.io/badge/license-apache-blue.svg?logo=apache)](LICENSE-APACHE)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](../main/CODE_OF_CONDUCT.md)
 
 [![Banner](banner.png)](https://traverseresearch.nl)

--- a/examples/d3d12-buffer-winrs.rs
+++ b/examples/d3d12-buffer-winrs.rs
@@ -123,7 +123,7 @@ fn main() -> Result<()> {
                 allocation.offset(),
                 &test_buffer_desc,
                 D3D12_RESOURCE_STATE_COMMON,
-                std::ptr::null(),
+                None,
                 &mut resource,
             )
         }?;
@@ -171,7 +171,7 @@ fn main() -> Result<()> {
                 allocation.offset(),
                 &test_buffer_desc,
                 D3D12_RESOURCE_STATE_COMMON,
-                std::ptr::null(),
+                None,
                 &mut resource,
             )
         }?;
@@ -219,7 +219,7 @@ fn main() -> Result<()> {
                 allocation.offset(),
                 &test_buffer_desc,
                 D3D12_RESOURCE_STATE_COMMON,
-                std::ptr::null(),
+                None,
                 &mut resource,
             )
         }?;

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -560,10 +560,8 @@ impl Allocator {
         unsafe {
             device.CheckFeatureSupport(
                 D3D12_FEATURE_D3D12_OPTIONS,
-                std::slice::from_raw_parts_mut(
-                    <*mut D3D12_FEATURE_DATA_D3D12_OPTIONS>::cast(&mut options),
-                    std::mem::size_of_val(&options),
-                ),
+                <*mut D3D12_FEATURE_DATA_D3D12_OPTIONS>::cast(&mut options),
+                std::mem::size_of_val(&options) as u32,
             )
         }
         .map_err(|e| {

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -560,8 +560,10 @@ impl Allocator {
         unsafe {
             device.CheckFeatureSupport(
                 D3D12_FEATURE_D3D12_OPTIONS,
-                <*mut D3D12_FEATURE_DATA_D3D12_OPTIONS>::cast(&mut options),
-                std::mem::size_of_val(&options) as u32,
+                std::slice::from_raw_parts_mut(
+                    <*mut D3D12_FEATURE_DATA_D3D12_OPTIONS>::cast(&mut options),
+                    std::mem::size_of_val(&options),
+                ),
             )
         }
         .map_err(|e| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@
 //!         allocation.offset(),
 //!         &buffer_desc,
 //!         Direct3D12::D3D12_RESOURCE_STATE_COMMON,
-//!         std::ptr::null(),
+//!         None,
 //!         &mut resource,
 //!     )
 //! }?;


### PR DESCRIPTION
These rapid bumps are a bit unfortunate, and we're still early in the adoption/improvement phase for windows-rs. See also https://github.com/microsoft/windows-rs/issues/1720.
