### PR TITLE
Initial memory visualizer for Vulkan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1.0"
 # such as the ability to link/load a Vulkan library.
 ash = { version = ">=0.34, <=0.37", optional = true, default-features = false, features = ["debug"] }
 # Only needed for visualizer.
-imgui = { version = "0.8", optional = true }
+imgui = { version = "0.8", features = ["tables-api"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 # Only needed for public-winapi interop helpers

--- a/src/allocator/dedicated_block_allocator/mod.rs
+++ b/src/allocator/dedicated_block_allocator/mod.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "visualizer")]
 pub(crate) mod visualizer;
 
-use super::{resolve_backtrace, AllocationType, AllocationReport, SubAllocator, SubAllocatorBase};
+use super::{resolve_backtrace, AllocationReport, AllocationType, SubAllocator, SubAllocatorBase};
 use crate::{AllocationError, Result};
 use log::{log, Level};
 
@@ -109,7 +109,10 @@ impl SubAllocator for DedicatedBlockAllocator {
 
     fn report_allocations(&self) -> Vec<AllocationReport> {
         vec![AllocationReport {
-            name: self.name.clone().unwrap_or_else(|| "<Unnamed Dedicated allocation>".to_owned()),
+            name: self
+                .name
+                .clone()
+                .unwrap_or_else(|| "<Unnamed Dedicated allocation>".to_owned()),
             size: self.size,
             backtrace: self.backtrace.clone(),
         }]

--- a/src/allocator/free_list_allocator/mod.rs
+++ b/src/allocator/free_list_allocator/mod.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "visualizer")]
 pub(crate) mod visualizer;
 
-use super::{AllocationType, SubAllocator, SubAllocatorBase};
+use super::{resolve_backtrace, AllocationType, AllocationReport, SubAllocator, SubAllocatorBase};
 use crate::{AllocationError, Result};
 
 use log::{log, Level};
@@ -26,7 +26,7 @@ pub(crate) struct MemoryChunk {
     pub(crate) offset: u64,
     pub(crate) allocation_type: AllocationType,
     pub(crate) name: Option<String>,
-    pub(crate) backtrace: Option<String>, // Only used if STORE_STACK_TRACES is true
+    pub(crate) backtrace: Option<backtrace::Backtrace>, // Only used if STORE_STACK_TRACES is true
     next: Option<std::num::NonZeroU64>,
     prev: Option<std::num::NonZeroU64>,
 }
@@ -156,7 +156,7 @@ impl SubAllocator for FreeListAllocator {
         allocation_type: AllocationType,
         granularity: u64,
         name: &str,
-        backtrace: Option<&str>,
+        backtrace: Option<backtrace::Backtrace>,
     ) -> Result<(u64, std::num::NonZeroU64)> {
         let free_size = self.size - self.allocated;
         if size > free_size {
@@ -243,7 +243,7 @@ impl SubAllocator for FreeListAllocator {
                     offset: free_chunk.offset,
                     allocation_type,
                     name: Some(name.to_string()),
-                    backtrace: backtrace.map(|s| s.to_owned()),
+                    backtrace,
                     prev: free_chunk.prev,
                     next: Some(first_fit_id),
                 };
@@ -356,7 +356,7 @@ impl SubAllocator for FreeListAllocator {
             }
             let empty = "".to_string();
             let name = chunk.name.as_ref().unwrap_or(&empty);
-            let backtrace = chunk.backtrace.as_ref().unwrap_or(&empty);
+            let backtrace = resolve_backtrace(&chunk.backtrace);
 
             log!(
                 log_level,
@@ -383,12 +383,23 @@ impl SubAllocator for FreeListAllocator {
             );
         }
     }
+    
+    fn report_allocations(&self) -> Vec<AllocationReport> {
+        self.chunks.iter().filter(|(_key, chunk)| chunk.allocation_type != AllocationType::Free).map(|(_key, chunk)| AllocationReport {
+            name: chunk.name.clone().unwrap_or_else(|| "<Unnamed FreeList allocation>".to_owned()),
+            size: chunk.size,
+            backtrace: chunk.backtrace.clone(),
+        }).collect::<Vec<_>>()
+    }
+
     fn size(&self) -> u64 {
         self.size
     }
+
     fn allocated(&self) -> u64 {
         self.allocated
     }
+
     fn supports_general_allocations(&self) -> bool {
         true
     }

--- a/src/allocator/free_list_allocator/mod.rs
+++ b/src/allocator/free_list_allocator/mod.rs
@@ -272,7 +272,7 @@ impl SubAllocator for FreeListAllocator {
 
             chunk.allocation_type = allocation_type;
             chunk.name = Some(name.to_string());
-            chunk.backtrace = backtrace.map(|s| s.to_owned());
+            chunk.backtrace = backtrace;
 
             self.remove_id_from_free_list(first_fit_id);
 

--- a/src/allocator/free_list_allocator/mod.rs
+++ b/src/allocator/free_list_allocator/mod.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "visualizer")]
 pub(crate) mod visualizer;
 
-use super::{resolve_backtrace, AllocationType, AllocationReport, SubAllocator, SubAllocatorBase};
+use super::{resolve_backtrace, AllocationReport, AllocationType, SubAllocator, SubAllocatorBase};
 use crate::{AllocationError, Result};
 
 use log::{log, Level};
@@ -383,13 +383,20 @@ impl SubAllocator for FreeListAllocator {
             );
         }
     }
-    
+
     fn report_allocations(&self) -> Vec<AllocationReport> {
-        self.chunks.iter().filter(|(_key, chunk)| chunk.allocation_type != AllocationType::Free).map(|(_key, chunk)| AllocationReport {
-            name: chunk.name.clone().unwrap_or_else(|| "<Unnamed FreeList allocation>".to_owned()),
-            size: chunk.size,
-            backtrace: chunk.backtrace.clone(),
-        }).collect::<Vec<_>>()
+        self.chunks
+            .iter()
+            .filter(|(_key, chunk)| chunk.allocation_type != AllocationType::Free)
+            .map(|(_key, chunk)| AllocationReport {
+                name: chunk
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| "<Unnamed FreeList allocation>".to_owned()),
+                size: chunk.size,
+                backtrace: chunk.backtrace.clone(),
+            })
+            .collect::<Vec<_>>()
     }
 
     fn size(&self) -> u64 {

--- a/src/allocator/free_list_allocator/visualizer.rs
+++ b/src/allocator/free_list_allocator/visualizer.rs
@@ -76,13 +76,11 @@ impl SubAllocatorVisualizer for FreeListAllocator {
                             if let Some(name) = &chunk.name {
                                 ui.text(format!("name: {:?}", name));
                             }
-                            if show_backtraces {
-                                if chunk.backtrace.is_some() {
-                                    ui.text(format!(
-                                        "backtrace: {:}",
-                                        resolve_backtrace(&chunk.backtrace)
-                                    ));
-                                }
+                            if show_backtraces && chunk.backtrace.is_some() {
+                                ui.text(format!(
+                                    "backtrace: {:}",
+                                    resolve_backtrace(&chunk.backtrace)
+                                ));
                             }
                         })
                     }

--- a/src/allocator/free_list_allocator/visualizer.rs
+++ b/src/allocator/free_list_allocator/visualizer.rs
@@ -1,4 +1,4 @@
-use super::{AllocationType, FreeListAllocator};
+use super::{resolve_backtrace, AllocationType, FreeListAllocator};
 use crate::visualizer::{ColorScheme, SubAllocatorVisualizer};
 
 impl SubAllocatorVisualizer for FreeListAllocator {
@@ -77,8 +77,8 @@ impl SubAllocatorVisualizer for FreeListAllocator {
                                 ui.text(format!("name: {:?}", name));
                             }
                             if show_backtraces {
-                                if let Some(backtrace) = &chunk.backtrace {
-                                    ui.text(format!("backtrace: {:}", backtrace));
+                                if chunk.backtrace.is_some() {
+                                    ui.text(format!("backtrace: {:}", resolve_backtrace(&chunk.backtrace)));
                                 }
                             }
                         })

--- a/src/allocator/free_list_allocator/visualizer.rs
+++ b/src/allocator/free_list_allocator/visualizer.rs
@@ -78,7 +78,10 @@ impl SubAllocatorVisualizer for FreeListAllocator {
                             }
                             if show_backtraces {
                                 if chunk.backtrace.is_some() {
-                                    ui.text(format!("backtrace: {:}", resolve_backtrace(&chunk.backtrace)));
+                                    ui.text(format!(
+                                        "backtrace: {:}",
+                                        resolve_backtrace(&chunk.backtrace)
+                                    ));
                                 }
                             }
                         })

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -24,13 +24,14 @@ pub(crate) struct AllocationReport {
 }
 
 pub(crate) fn resolve_backtrace(backtrace: &Option<backtrace::Backtrace>) -> String {
-    if let Some(bt) = backtrace {
-        let mut bt = bt.clone();
-        bt.resolve();
-        format!("{:?}", bt)
-    } else {
-        "".to_owned()
-    }
+    backtrace.as_ref().map_or_else(
+        || "".to_owned(),
+        |bt| {
+            let mut bt = bt.clone();
+            bt.resolve();
+            format!("{:?}", bt)
+        },
+    )
 }
 
 #[cfg(feature = "visualizer")]

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -30,6 +30,7 @@ pub struct AllocatorVisualizer {
     selected_blocks: Vec<AllocatorVisualizerBlockWindow>,
     focus: Option<usize>,
     color_scheme: ColorScheme,
+    allocation_breakdown_sorting: Option<(Option<imgui::TableSortDirection>, usize)>,
 }
 
 fn format_heap_type(heap_type: D3D12_HEAP_TYPE) -> &'static str {
@@ -71,6 +72,7 @@ impl AllocatorVisualizer {
             selected_blocks: Vec::default(),
             focus: None,
             color_scheme: ColorScheme::default(),
+            allocation_breakdown_sorting: None,
         }
     }
 
@@ -287,8 +289,87 @@ impl AllocatorVisualizer {
     /// - If [`true`], the widget will be drawn and an (X) closing button will be added to the widget bar.
     pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui<'_>, opened: Option<&mut bool>) {
         if opened != Some(&mut false) {
-            self.render_main_window(ui, opened, allocator);
-            self.render_memory_block_windows(ui, allocator);
+            // self.render_main_window(ui, opened, allocator);
+            // self.render_memory_block_windows(ui, allocator);
+
+            self.render_breakdown(allocator, ui, opened);
         }
+    }
+
+    pub fn render_breakdown(&mut self, allocator: &Allocator, ui: &imgui::Ui<'_>, opened: Option<&mut bool>) {
+        imgui::Window::new("Allocation Breakdown")
+        .position([20.0f32, 80.0f32], imgui::Condition::FirstUseEver)
+        .size([460.0f32, 420.0f32], imgui::Condition::FirstUseEver)
+        .opened(opened.unwrap_or(&mut false))
+        .build(ui, || {
+            let mut allocation_report = vec![];
+
+            for memory_type in &allocator.memory_types {
+                for block in &memory_type.memory_blocks {
+                    if let Some(block) = block {
+                        allocation_report.extend_from_slice(&block.sub_allocator.report_allocations())
+                    }
+                }
+            }
+
+            if let Some(_t) = ui.begin_table_header_with_flags(
+                "alloc_breakdown_table",
+                [
+                    imgui::TableColumnSetup {
+                        flags: imgui::TableColumnFlags::WIDTH_FIXED,
+                        init_width_or_weight: 50.0,
+                        ..imgui::TableColumnSetup::new("Idx")
+                    },
+                    imgui::TableColumnSetup::new("Name"),
+                    imgui::TableColumnSetup {
+                        flags: imgui::TableColumnFlags::WIDTH_FIXED,
+                        init_width_or_weight: 150.0,
+                        ..imgui::TableColumnSetup::new("Size")
+                    },
+                ],
+                imgui::TableFlags::SORTABLE | imgui::TableFlags::RESIZABLE,
+            ) {
+                let mut allocation_report = allocation_report.iter().enumerate().collect::<Vec<_>>();
+
+                if let Some(mut sort_data) = ui.table_sort_specs_mut() {
+                    if sort_data.should_sort() {
+                        let specs = sort_data.specs();
+                        let spec = specs.iter().next().unwrap();
+                        self.allocation_breakdown_sorting =
+                            Some((spec.sort_direction(), spec.column_idx()));
+                        sort_data.set_sorted();
+                    }
+                }
+
+                if let Some((Some(dir), column_idx)) = self.allocation_breakdown_sorting {
+                    match dir {
+                        imgui::TableSortDirection::Ascending => match column_idx {
+                            0 => allocation_report.sort_by_key(|(idx, _)| *idx),
+                            1 => allocation_report.sort_by_key(|(_, alloc)| &alloc.name),
+                            2 => allocation_report.sort_by_key(|(_, alloc)| alloc.size),
+                            _ => unimplemented!(),
+                        },
+                        imgui::TableSortDirection::Descending => match column_idx {
+                            0 => allocation_report.sort_by_key(|(idx, _)| std::cmp::Reverse(*idx)),
+                            1 => allocation_report
+                                .sort_by_key(|(_, alloc)| std::cmp::Reverse(&alloc.name)),
+                            2 => allocation_report.sort_by_key(|(_, alloc)| std::cmp::Reverse(alloc.size)),
+                            _ => unimplemented!(),
+                        },
+                    }
+                }
+
+                for (idx, alloc) in &allocation_report {
+                    ui.table_next_column();
+                    ui.text(idx.to_string());
+
+                    ui.table_next_column();
+                    ui.text(&alloc.name);
+
+                    ui.table_next_column();
+                    ui.text(format!("{:.3?}", alloc.size));
+                }
+            }
+        });
     }
 }

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -289,9 +289,6 @@ impl AllocatorVisualizer {
     /// - If [`true`], the widget will be drawn and an (X) closing button will be added to the widget bar.
     pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui<'_>, opened: Option<&mut bool>) {
         if opened != Some(&mut false) {
-            // self.render_main_window(ui, opened, allocator);
-            // self.render_memory_block_windows(ui, allocator);
-
             self.render_breakdown(allocator, ui, opened);
         }
     }

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -3,8 +3,8 @@
 use super::Allocator;
 use crate::visualizer::ColorScheme;
 
-use windows::Win32::Graphics::Direct3D12::*;
 use log::error;
+use windows::Win32::Graphics::Direct3D12::*;
 
 // Default value for block visualizer granularity.
 #[allow(dead_code)]

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -231,7 +231,7 @@ impl MemoryType {
         device: &ash::Device,
         desc: &AllocationCreateDesc<'_>,
         granularity: u64,
-        backtrace: Option<&str>,
+        backtrace: Option<backtrace::Backtrace>,
     ) -> Result<Allocation> {
         let allocation_type = if desc.linear {
             AllocationType::Linear
@@ -315,7 +315,7 @@ impl MemoryType {
                     allocation_type,
                     granularity,
                     desc.name,
-                    backtrace,
+                    backtrace.clone(),
                 );
 
                 match allocation {
@@ -551,7 +551,7 @@ impl Allocator {
         let alignment = desc.requirements.alignment;
 
         let backtrace = if self.debug_settings.store_stack_traces {
-            Some(format!("{:?}", backtrace::Backtrace::new()))
+            Some(backtrace::Backtrace::new_unresolved())
         } else {
             None
         };
@@ -562,10 +562,8 @@ impl Allocator {
                 &desc.name, size, alignment
             );
             if self.debug_settings.log_stack_traces {
-                let backtrace = backtrace
-                    .clone()
-                    .unwrap_or(format!("{:?}", backtrace::Backtrace::new()));
-                debug!("Allocation stack trace: {}", &backtrace);
+                let backtrace = backtrace::Backtrace::new();
+                debug!("Allocation stack trace: {:?}", backtrace);
             }
         }
 
@@ -617,7 +615,7 @@ impl Allocator {
                 &self.device,
                 desc,
                 self.buffer_image_granularity,
-                backtrace.as_deref(),
+                backtrace.clone(),
             )
         };
 
@@ -638,7 +636,7 @@ impl Allocator {
                     &self.device,
                     desc,
                     self.buffer_image_granularity,
-                    backtrace.as_deref(),
+                    backtrace,
                 )
             } else {
                 allocation

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::new_without_default)]
 
-use super::Allocator;
+use super::{Allocator};
+use crate::allocator::resolve_backtrace;
 use crate::visualizer::ColorScheme;
 
 // Default value for block visualizer granularity.
@@ -26,6 +27,8 @@ pub struct AllocatorVisualizer {
     selected_blocks: Vec<AllocatorVisualizerBlockWindow>,
     focus: Option<usize>,
     color_scheme: ColorScheme,
+    allocation_breakdown_sorting: Option<(Option<imgui::TableSortDirection>, usize)>,
+    breakdown_filter: String,
 }
 
 impl AllocatorVisualizer {
@@ -34,6 +37,8 @@ impl AllocatorVisualizer {
             selected_blocks: Vec::default(),
             focus: None,
             color_scheme: ColorScheme::default(),
+            allocation_breakdown_sorting: None,
+            breakdown_filter: String::new(),
         }
     }
 
@@ -274,5 +279,122 @@ impl AllocatorVisualizer {
             self.render_main_window(ui, opened, allocator);
             self.render_memory_block_windows(ui, allocator);
         }
+    }
+    
+    pub fn render_breakdown(&mut self, allocator: &Allocator, ui: &imgui::Ui<'_>, opened: Option<&mut bool>) {
+        let mut allocation_report = vec![];
+        let mut total_size_in_bytes = 0;
+
+        if let Some(true) = opened {
+            let lowercase_needle = &self.breakdown_filter.to_lowercase();
+            for memory_type in &allocator.memory_types {
+                for block in &memory_type.memory_blocks {
+                    if let Some(block) = block {
+                        for report in block.sub_allocator.report_allocations() {
+                            if self.breakdown_filter.is_empty() || report.name.to_lowercase().contains(lowercase_needle) {
+                                allocation_report.push(report);
+                            }
+                        }
+                    }
+                }
+            }
+
+            total_size_in_bytes = allocation_report.iter().map(|report| report.size).sum();
+        }
+
+        let suffix = ["B", "KB", "MB", "GB", "TB"];
+
+        let fmt_bytes = |mut amount: u64| -> String {
+            let mut idx = 0;
+            let mut print_amount = amount as f64;
+            loop {
+                if amount < 1024 {
+                    return format!("{:.2} {}", print_amount, suffix[idx]);
+                }
+
+                print_amount = amount as f64 / 1024.0;
+                amount /= 1024;
+                idx += 1;
+            }
+        };
+
+        let mut window = imgui::Window::new(format!("Allocation Breakdown ({})###allocation_breakdown_window", fmt_bytes(total_size_in_bytes)))
+            .position([20.0f32, 80.0f32], imgui::Condition::FirstUseEver)
+            .size([460.0f32, 420.0f32], imgui::Condition::FirstUseEver);
+        
+        if let Some(opened) = opened {
+            window = window.opened(opened);
+        }
+
+        window.build(ui, || {
+            ui.input_text("Filter", &mut self.breakdown_filter).build();
+
+            if let Some(_t) = ui.begin_table_header_with_flags(
+                "alloc_breakdown_table",
+                [
+                    imgui::TableColumnSetup {
+                        flags: imgui::TableColumnFlags::WIDTH_FIXED,
+                        init_width_or_weight: 50.0,
+                        ..imgui::TableColumnSetup::new("Idx")
+                    },
+                    imgui::TableColumnSetup::new("Name"),
+                    imgui::TableColumnSetup {
+                        flags: imgui::TableColumnFlags::WIDTH_FIXED,
+                        init_width_or_weight: 150.0,
+                        ..imgui::TableColumnSetup::new("Size")
+                    },
+                ],
+                imgui::TableFlags::SORTABLE | imgui::TableFlags::RESIZABLE,
+            ) {
+                let mut allocation_report = allocation_report.iter().enumerate().collect::<Vec<_>>();
+
+                if let Some(mut sort_data) = ui.table_sort_specs_mut() {
+                    if sort_data.should_sort() {
+                        let specs = sort_data.specs();
+                        let spec = specs.iter().next().unwrap();
+                        self.allocation_breakdown_sorting =
+                            Some((spec.sort_direction(), spec.column_idx()));
+                        sort_data.set_sorted();
+                    }
+                }
+
+                if let Some((Some(dir), column_idx)) = self.allocation_breakdown_sorting {
+                    match dir {
+                        imgui::TableSortDirection::Ascending => match column_idx {
+                            0 => allocation_report.sort_by_key(|(idx, _)| *idx),
+                            1 => allocation_report.sort_by_key(|(_, alloc)| &alloc.name),
+                            2 => allocation_report.sort_by_key(|(_, alloc)| alloc.size),
+                            _ => unimplemented!(),
+                        },
+                        imgui::TableSortDirection::Descending => match column_idx {
+                            0 => allocation_report.sort_by_key(|(idx, _)| std::cmp::Reverse(*idx)),
+                            1 => allocation_report
+                                .sort_by_key(|(_, alloc)| std::cmp::Reverse(&alloc.name)),
+                            2 => allocation_report.sort_by_key(|(_, alloc)| std::cmp::Reverse(alloc.size)),
+                            _ => unimplemented!(),
+                        },
+                    }
+                }
+
+                for (idx, alloc) in &allocation_report {
+                    ui.table_next_column();
+                    ui.text(idx.to_string());
+
+                    ui.table_next_column();
+                    ui.text(&alloc.name);
+
+                    if ui.is_item_hovered() {
+                        if alloc.backtrace.is_some() {
+                            ui.tooltip(|| {
+                                ui.text(resolve_backtrace(&alloc.backtrace));
+                            });
+                        }
+                    }
+
+                    ui.table_next_column();
+                    ui.text(fmt_bytes(alloc.size));
+                }
+            }
+        });
     }
 }

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_without_default)]
 
-use super::{Allocator};
+use super::Allocator;
 use crate::allocator::resolve_backtrace;
 use crate::visualizer::ColorScheme;
 
@@ -280,8 +280,13 @@ impl AllocatorVisualizer {
             self.render_memory_block_windows(ui, allocator);
         }
     }
-    
-    pub fn render_breakdown(&mut self, allocator: &Allocator, ui: &imgui::Ui<'_>, opened: Option<&mut bool>) {
+
+    pub fn render_breakdown(
+        &mut self,
+        allocator: &Allocator,
+        ui: &imgui::Ui<'_>,
+        opened: Option<&mut bool>,
+    ) {
         let mut allocation_report = vec![];
         let mut total_size_in_bytes = 0;
 
@@ -291,7 +296,9 @@ impl AllocatorVisualizer {
                 for block in &memory_type.memory_blocks {
                     if let Some(block) = block {
                         for report in block.sub_allocator.report_allocations() {
-                            if self.breakdown_filter.is_empty() || report.name.to_lowercase().contains(lowercase_needle) {
+                            if self.breakdown_filter.is_empty()
+                                || report.name.to_lowercase().contains(lowercase_needle)
+                            {
                                 allocation_report.push(report);
                             }
                         }
@@ -318,10 +325,13 @@ impl AllocatorVisualizer {
             }
         };
 
-        let mut window = imgui::Window::new(format!("Allocation Breakdown ({})###allocation_breakdown_window", fmt_bytes(total_size_in_bytes)))
-            .position([20.0f32, 80.0f32], imgui::Condition::FirstUseEver)
-            .size([460.0f32, 420.0f32], imgui::Condition::FirstUseEver);
-        
+        let mut window = imgui::Window::new(format!(
+            "Allocation Breakdown ({})###allocation_breakdown_window",
+            fmt_bytes(total_size_in_bytes)
+        ))
+        .position([20.0f32, 80.0f32], imgui::Condition::FirstUseEver)
+        .size([460.0f32, 420.0f32], imgui::Condition::FirstUseEver);
+
         if let Some(opened) = opened {
             window = window.opened(opened);
         }
@@ -329,24 +339,28 @@ impl AllocatorVisualizer {
         window.build(ui, || {
             ui.input_text("Filter", &mut self.breakdown_filter).build();
 
-            if let Some(_t) = ui.begin_table_header_with_flags(
-                "alloc_breakdown_table",
-                [
-                    imgui::TableColumnSetup {
-                        flags: imgui::TableColumnFlags::WIDTH_FIXED,
-                        init_width_or_weight: 50.0,
-                        ..imgui::TableColumnSetup::new("Idx")
-                    },
-                    imgui::TableColumnSetup::new("Name"),
-                    imgui::TableColumnSetup {
-                        flags: imgui::TableColumnFlags::WIDTH_FIXED,
-                        init_width_or_weight: 150.0,
-                        ..imgui::TableColumnSetup::new("Size")
-                    },
-                ],
-                imgui::TableFlags::SORTABLE | imgui::TableFlags::RESIZABLE,
-            ) {
-                let mut allocation_report = allocation_report.iter().enumerate().collect::<Vec<_>>();
+            if ui
+                .begin_table_header_with_flags(
+                    "alloc_breakdown_table",
+                    [
+                        imgui::TableColumnSetup {
+                            flags: imgui::TableColumnFlags::WIDTH_FIXED,
+                            init_width_or_weight: 50.0,
+                            ..imgui::TableColumnSetup::new("Idx")
+                        },
+                        imgui::TableColumnSetup::new("Name"),
+                        imgui::TableColumnSetup {
+                            flags: imgui::TableColumnFlags::WIDTH_FIXED,
+                            init_width_or_weight: 150.0,
+                            ..imgui::TableColumnSetup::new("Size")
+                        },
+                    ],
+                    imgui::TableFlags::SORTABLE | imgui::TableFlags::RESIZABLE,
+                )
+                .is_some()
+            {
+                let mut allocation_report =
+                    allocation_report.iter().enumerate().collect::<Vec<_>>();
 
                 if let Some(mut sort_data) = ui.table_sort_specs_mut() {
                     if sort_data.should_sort() {
@@ -370,7 +384,8 @@ impl AllocatorVisualizer {
                             0 => allocation_report.sort_by_key(|(idx, _)| std::cmp::Reverse(*idx)),
                             1 => allocation_report
                                 .sort_by_key(|(_, alloc)| std::cmp::Reverse(&alloc.name)),
-                            2 => allocation_report.sort_by_key(|(_, alloc)| std::cmp::Reverse(alloc.size)),
+                            2 => allocation_report
+                                .sort_by_key(|(_, alloc)| std::cmp::Reverse(alloc.size)),
                             _ => unimplemented!(),
                         },
                     }


### PR DESCRIPTION
This actually does two things;

- It has an optimization for the callstack resolution which now only happens when it needs to instead of eagerly doing it all the time. This saves significant time in dbghelp.dll and saves some memory too since we only need to store the stack pointers instead of the string
- It includes a new allocation overview window that is just a flat list of all allocations that are currently being held by the allocator, including their name. This makes it super easy to track down where memory is being wasted.