### PR TITLE
Use formatter precision to limit number of lines printed in the allocator breakdown

### DIFF
--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -767,7 +767,11 @@ impl fmt::Debug for Allocator {
             fmt_bytes(total_size_in_bytes)
         )?;
 
-        for alloc in &allocation_report {
+        let max_num_allocations_to_print = f.precision().map_or(usize::MAX, |n| n);
+        for (idx, alloc) in allocation_report.iter().enumerate() {
+            if idx >= max_num_allocations_to_print {
+                break;
+            }
             writeln!(
                 f,
                 "{:max_len$.max_len$}\t- {}",

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -478,7 +478,6 @@ impl fmt::Debug for Allocator {
         )?;
 
         let max_num_allocations_to_print = f.precision().map_or(usize::MAX, |n| n);
-
         for (idx, alloc) in allocation_report.iter().enumerate() {
             if idx >= max_num_allocations_to_print {
                 break;

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -477,7 +477,13 @@ impl fmt::Debug for Allocator {
             fmt_bytes(total_size_in_bytes)
         )?;
 
-        for alloc in &allocation_report {
+        let max_num_allocations_to_print = f.precision().map_or(usize::MAX, |n| n);
+
+        for (idx, alloc) in allocation_report.iter().enumerate() {
+            if idx >= max_num_allocations_to_print {
+                break;
+            }
+
             writeln!(
                 f,
                 "{:max_len$.max_len$}\t- {}",


### PR DESCRIPTION
A handy way to limit the number of lines printed by the allocator breakdown using the precision syntax in the calling code.
I.E.: `println!("{:.20?}", alloc);`