### PR TITLE
examples: Initialize `env_logger` to actually see `log` output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ ash = { version = "0.37", default-features = false, features = ["debug", "loaded
 ash-window = "0.12"
 raw-window-handle = "0.5"
 winit = { version = "0.27", features = ["x11", "wayland"] }
+env_logger = "0.10"
 
 [target.'cfg(windows)'.dev-dependencies]
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }

--- a/examples/d3d12-buffer-winrs.rs
+++ b/examples/d3d12-buffer-winrs.rs
@@ -3,7 +3,7 @@ use gpu_allocator::d3d12::{
     AllocationCreateDesc, Allocator, AllocatorCreateDesc, ResourceCategory,
 };
 use gpu_allocator::MemoryLocation;
-use log::error;
+use log::*;
 use windows::core::{Interface, Result};
 use windows::Win32::{
     Foundation::E_NOINTERFACE,
@@ -54,7 +54,7 @@ fn create_d3d12_device(dxgi_factory: &IDXGIFactory6) -> Option<ID3D12Device> {
                     let mut device = None;
                     match unsafe { D3D12CreateDevice(&adapter4, feature_level, &mut device) } {
                         Ok(()) => {
-                            println!("Using D3D12 feature level: {}", feature_level_name);
+                            info!("Using D3D12 feature level: {}", feature_level_name);
                             Some(device.unwrap())
                         }
                         Err(e) if e.code() == E_NOINTERFACE => {
@@ -62,7 +62,7 @@ fn create_d3d12_device(dxgi_factory: &IDXGIFactory6) -> Option<ID3D12Device> {
                             None
                         }
                         Err(e) => {
-                            println!(
+                            info!(
                                 "D3D12 feature level {} not supported: {}",
                                 feature_level_name, e
                             );
@@ -79,6 +79,8 @@ fn create_d3d12_device(dxgi_factory: &IDXGIFactory6) -> Option<ID3D12Device> {
 }
 
 fn main() -> Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init();
+
     let dxgi_factory = unsafe { CreateDXGIFactory2(0) }?;
 
     let device = create_d3d12_device(&dxgi_factory).expect("Failed to create D3D12 device.");
@@ -131,7 +133,7 @@ fn main() -> Result<()> {
         drop(resource);
 
         allocator.free(allocation).unwrap();
-        println!("Allocation and deallocation of GpuOnly memory was successful.");
+        info!("Allocation and deallocation of GpuOnly memory was successful.");
     }
 
     // Test allocating Cpu to Gpu memory
@@ -179,7 +181,7 @@ fn main() -> Result<()> {
         drop(resource);
 
         allocator.free(allocation).unwrap();
-        println!("Allocation and deallocation of CpuToGpu memory was successful.");
+        info!("Allocation and deallocation of CpuToGpu memory was successful.");
     }
 
     // Test allocating Gpu to Cpu memory
@@ -227,7 +229,7 @@ fn main() -> Result<()> {
         drop(resource);
 
         allocator.free(allocation).unwrap();
-        println!("Allocation and deallocation of CpuToGpu memory was successful.");
+        info!("Allocation and deallocation of CpuToGpu memory was successful.");
     }
 
     Ok(())

--- a/examples/d3d12-buffer.rs
+++ b/examples/d3d12-buffer.rs
@@ -68,7 +68,7 @@ fn create_d3d12_device(
                     };
                     match hr {
                         winapi::shared::winerror::S_OK => {
-                            println!("Using D3D12 feature level: {}.", feature_level_name);
+                            info!("Using D3D12 feature level: {}.", feature_level_name);
                             Some(device)
                         }
                         winapi::shared::winerror::E_NOINTERFACE => {
@@ -93,6 +93,8 @@ fn create_d3d12_device(
 }
 
 fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init();
+
     let dxgi_factory = {
         let mut dxgi_factory: *mut all_dxgi::IDXGIFactory6 = std::ptr::null_mut();
         let hr = unsafe {
@@ -167,7 +169,7 @@ fn main() {
         unsafe { resource.as_ref().unwrap().Release() };
 
         allocator.free(allocation).unwrap();
-        println!("Allocation and deallocation of GpuOnly memory was successful.");
+        info!("Allocation and deallocation of GpuOnly memory was successful.");
     }
 
     // Test allocating Cpu to Gpu memory
@@ -219,7 +221,7 @@ fn main() {
         unsafe { resource.as_ref().unwrap().Release() };
 
         allocator.free(allocation).unwrap();
-        println!("Allocation and deallocation of CpuToGpu memory was successful.");
+        info!("Allocation and deallocation of CpuToGpu memory was successful.");
     }
 
     // Test allocating Gpu to Cpu memory
@@ -271,7 +273,7 @@ fn main() {
         unsafe { resource.as_ref().unwrap().Release() };
 
         allocator.free(allocation).unwrap();
-        println!("Allocation and deallocation of CpuToGpu memory was successful.");
+        info!("Allocation and deallocation of CpuToGpu memory was successful.");
     }
 
     drop(allocator); // Explicitly drop before destruction of device.

--- a/examples/d3d12-visualization/main.rs
+++ b/examples/d3d12-visualization/main.rs
@@ -1,5 +1,6 @@
 #![windows_subsystem = "windows"]
 //! Example showcasing [`winapi`] interop with [`gpu-allocator`] which is driven by the [`windows`] crate.
+use log::info;
 use raw_window_handle::HasRawWindowHandle;
 
 use gpu_allocator::d3d12::{Allocator, AllocatorCreateDesc, ToWindows};
@@ -128,6 +129,8 @@ fn transition_resource(
 }
 
 fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init();
+
     // Disable automatic DPI scaling by windows
     unsafe { winuser::SetProcessDPIAware() };
 
@@ -151,7 +154,7 @@ fn main() {
     std::thread::spawn(move || {
         let mut dxgi_factory_flags = 0;
         if ENABLE_DEBUG_LAYER && enable_d3d12_debug_layer() {
-            println!("Enabled D3D12 debug layer");
+            info!("Enabled D3D12 debug layer");
             dxgi_factory_flags |= all_dxgi::DXGI_CREATE_FACTORY_DEBUG;
         }
 

--- a/examples/vulkan-buffer.rs
+++ b/examples/vulkan-buffer.rs
@@ -1,4 +1,5 @@
 use ash::vk;
+use log::info;
 
 use std::default::Default;
 use std::ffi::CString;
@@ -7,9 +8,11 @@ use gpu_allocator::vulkan::{AllocationCreateDesc, Allocator, AllocatorCreateDesc
 use gpu_allocator::MemoryLocation;
 
 fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init();
+
     let entry = unsafe { ash::Entry::load() }.unwrap();
 
-    // Create vulkan instance
+    // Create Vulkan instance
     let instance = {
         let app_name = CString::new("Vulkan gpu-allocator test").unwrap();
 
@@ -125,7 +128,7 @@ fn main() {
 
         unsafe { device.destroy_buffer(test_buffer, None) };
 
-        println!("Allocation and deallocation of GpuOnly memory was successful.");
+        info!("Allocation and deallocation of GpuOnly memory was successful.");
     }
 
     // Test allocating Cpu to Gpu memory
@@ -157,7 +160,7 @@ fn main() {
 
         unsafe { device.destroy_buffer(test_buffer, None) };
 
-        println!("Allocation and deallocation of CpuToGpu memory was successful.");
+        info!("Allocation and deallocation of CpuToGpu memory was successful.");
     }
 
     // Test allocating Gpu to Cpu memory
@@ -189,7 +192,7 @@ fn main() {
 
         unsafe { device.destroy_buffer(test_buffer, None) };
 
-        println!("Allocation and deallocation of GpuToCpu memory was successful.");
+        info!("Allocation and deallocation of GpuToCpu memory was successful.");
     }
 
     drop(allocator); // Explicitly drop before destruction of device and instance.

--- a/examples/vulkan-visualization/main.rs
+++ b/examples/vulkan-visualization/main.rs
@@ -12,6 +12,8 @@ mod helper;
 use helper::record_and_submit_command_buffer;
 
 fn main() -> ash::prelude::VkResult<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init();
+
     let entry = unsafe { ash::Entry::load() }.unwrap();
 
     let event_loop = winit::event_loop::EventLoop::new();


### PR DESCRIPTION
`log` only provides the facade, and needs an explicitly initialized logger to emit output to `stdout`.  The `env_logger` crate is typically used across the Rust ecosystem, but unfortunately initializes with a default of `off` unless the `RUST_LOG` variable is set: default it to `trace` instead (we mostly log on `info` though).
