### PR TITLE
Add support for dedicated allocations and committed resource tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ let allocation = allocator
         requirements,
         location: MemoryLocation::CpuToGpu,
         linear: true, // Buffers are always linear
+        dedicated_allocation: false,
     }).unwrap();
 
 // Bind memory to the buffer

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ let allocation = allocator
         requirements,
         location: MemoryLocation::CpuToGpu,
         linear: true, // Buffers are always linear
-        dedicated_allocation: false,
+        allocation_scheme: AllocationScheme::GpuAllocatorManaged,
     }).unwrap();
 
 // Bind memory to the buffer

--- a/examples/vulkan-buffer.rs
+++ b/examples/vulkan-buffer.rs
@@ -111,6 +111,7 @@ fn main() {
                 requirements,
                 location,
                 linear: true,
+                dedicated_allocation: false,
                 name: "Test allocation (Gpu Only)",
             })
             .unwrap();
@@ -143,6 +144,7 @@ fn main() {
                 requirements,
                 location,
                 linear: true,
+                dedicated_allocation: false,
                 name: "Test allocation (Cpu to Gpu)",
             })
             .unwrap();
@@ -175,6 +177,7 @@ fn main() {
                 requirements,
                 location,
                 linear: true,
+                dedicated_allocation: false,
                 name: "Test allocation (Gpu to Cpu)",
             })
             .unwrap();

--- a/examples/vulkan-buffer.rs
+++ b/examples/vulkan-buffer.rs
@@ -3,7 +3,9 @@ use ash::vk;
 use std::default::Default;
 use std::ffi::CString;
 
-use gpu_allocator::vulkan::{AllocationCreateDesc, Allocator, AllocatorCreateDesc};
+use gpu_allocator::vulkan::{
+    AllocationCreateDesc, AllocationScheme, Allocator, AllocatorCreateDesc,
+};
 use gpu_allocator::MemoryLocation;
 
 fn main() {
@@ -111,7 +113,7 @@ fn main() {
                 requirements,
                 location,
                 linear: true,
-                dedicated_allocation: false,
+                allocation_scheme: AllocationScheme::GpuAllocatorManaged,
                 name: "Test allocation (Gpu Only)",
             })
             .unwrap();
@@ -144,7 +146,7 @@ fn main() {
                 requirements,
                 location,
                 linear: true,
-                dedicated_allocation: false,
+                allocation_scheme: AllocationScheme::GpuAllocatorManaged,
                 name: "Test allocation (Cpu to Gpu)",
             })
             .unwrap();
@@ -177,7 +179,7 @@ fn main() {
                 requirements,
                 location,
                 linear: true,
-                dedicated_allocation: false,
+                allocation_scheme: AllocationScheme::GpuAllocatorManaged,
                 name: "Test allocation (Gpu to Cpu)",
             })
             .unwrap();

--- a/examples/vulkan-visualization/imgui_renderer.rs
+++ b/examples/vulkan-visualization/imgui_renderer.rs
@@ -283,6 +283,7 @@ impl ImGuiRenderer {
                     requirements,
                     location: MemoryLocation::GpuOnly,
                     linear: false,
+                    dedicated_allocation: false,
                 })
                 .unwrap();
             unsafe { device.bind_image_memory(image, allocation.memory(), allocation.offset()) }
@@ -323,6 +324,7 @@ impl ImGuiRenderer {
                         requirements,
                         location: MemoryLocation::CpuToGpu,
                         linear: true,
+                        dedicated_allocation: false,
                     })
                     .unwrap();
 
@@ -481,6 +483,7 @@ impl ImGuiRenderer {
                     requirements,
                     location: MemoryLocation::CpuToGpu,
                     linear: true,
+                    dedicated_allocation: false,
                 })
                 .unwrap();
 
@@ -506,6 +509,7 @@ impl ImGuiRenderer {
                     requirements,
                     location: MemoryLocation::CpuToGpu,
                     linear: true,
+                    dedicated_allocation: false,
                 })
                 .unwrap();
 
@@ -529,6 +533,7 @@ impl ImGuiRenderer {
                     requirements,
                     location: MemoryLocation::CpuToGpu,
                     linear: true,
+                    dedicated_allocation: false,
                 })
                 .unwrap();
 

--- a/examples/vulkan-visualization/imgui_renderer.rs
+++ b/examples/vulkan-visualization/imgui_renderer.rs
@@ -1,7 +1,7 @@
 use ash::vk;
 
 use crate::helper::record_and_submit_command_buffer;
-use gpu_allocator::vulkan::{Allocation, AllocationCreateDesc, Allocator};
+use gpu_allocator::vulkan::{Allocation, AllocationCreateDesc, AllocationScheme, Allocator};
 use gpu_allocator::MemoryLocation;
 
 #[repr(C)]
@@ -283,7 +283,7 @@ impl ImGuiRenderer {
                     requirements,
                     location: MemoryLocation::GpuOnly,
                     linear: false,
-                    dedicated_allocation: false,
+                    allocation_scheme: AllocationScheme::GpuAllocatorManaged,
                 })
                 .unwrap();
             unsafe { device.bind_image_memory(image, allocation.memory(), allocation.offset()) }
@@ -324,7 +324,7 @@ impl ImGuiRenderer {
                         requirements,
                         location: MemoryLocation::CpuToGpu,
                         linear: true,
-                        dedicated_allocation: false,
+                        allocation_scheme: AllocationScheme::GpuAllocatorManaged,
                     })
                     .unwrap();
 
@@ -483,7 +483,7 @@ impl ImGuiRenderer {
                     requirements,
                     location: MemoryLocation::CpuToGpu,
                     linear: true,
-                    dedicated_allocation: false,
+                    allocation_scheme: AllocationScheme::GpuAllocatorManaged,
                 })
                 .unwrap();
 
@@ -509,7 +509,7 @@ impl ImGuiRenderer {
                     requirements,
                     location: MemoryLocation::CpuToGpu,
                     linear: true,
-                    dedicated_allocation: false,
+                    allocation_scheme: AllocationScheme::GpuAllocatorManaged,
                 })
                 .unwrap();
 
@@ -533,7 +533,7 @@ impl ImGuiRenderer {
                     requirements,
                     location: MemoryLocation::CpuToGpu,
                     linear: true,
-                    dedicated_allocation: false,
+                    allocation_scheme: AllocationScheme::GpuAllocatorManaged,
                 })
                 .unwrap();
 

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -24,6 +24,16 @@ mod public_winapi {
         fn as_windows(&self) -> &T;
     }
 
+    impl ToWinapi<winapi_d3d12::ID3D12Resource> for ID3D12Resource {
+        fn as_winapi(&self) -> *const winapi_d3d12::ID3D12Resource {
+            unsafe { std::mem::transmute_copy(self) }
+        }
+
+        fn as_winapi_mut(&mut self) -> *mut winapi_d3d12::ID3D12Resource {
+            unsafe { std::mem::transmute_copy(self) }
+        }
+    }
+
     impl ToWinapi<winapi_d3d12::ID3D12Device> for ID3D12Device {
         fn as_winapi(&self) -> *const winapi_d3d12::ID3D12Device {
             unsafe { std::mem::transmute_copy(self) }

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -794,7 +794,7 @@ impl Allocator {
         resource_desc: &D3D12_RESOURCE_DESC,
         clear_value: Option<&D3D12_CLEAR_VALUE>,
         initial_state: D3D12_RESOURCE_STATES,
-        resource_type: ResourceType<'_>,
+        resource_type: &ResourceType<'_>,
     ) -> Result<Resource> {
         match resource_type {
             ResourceType::Committed {
@@ -804,12 +804,12 @@ impl Allocator {
                 let mut result: Option<ID3D12Resource> = None;
 
                 let clear_value: Option<*const D3D12_CLEAR_VALUE> =
-                    clear_value.map(|v| v as *const D3D12_CLEAR_VALUE);
+                    clear_value.map(|v| <*const _>::cast(v));
 
                 if let Err(err) = unsafe {
                     self.device.CreateCommittedResource(
-                        heap_properties,
-                        heap_flags,
+                        *heap_properties,
+                        *heap_flags,
                         resource_desc,
                         initial_state,
                         clear_value,

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -792,6 +792,7 @@ impl Allocator {
         memory_location: MemoryLocation,
         resource_category: ResourceCategory,
         resource_desc: &D3D12_RESOURCE_DESC,
+        clear_value: Option<&D3D12_CLEAR_VALUE>,
         initial_state: D3D12_RESOURCE_STATES,
         resource_type: ResourceType<'_>,
     ) -> Result<Resource> {
@@ -801,13 +802,17 @@ impl Allocator {
                 heap_flags,
             } => {
                 let mut result: Option<ID3D12Resource> = None;
+
+                let clear_value: Option<*const D3D12_CLEAR_VALUE> =
+                    clear_value.map(|v| v as *const D3D12_CLEAR_VALUE);
+
                 if let Err(err) = unsafe {
                     self.device.CreateCommittedResource(
                         heap_properties,
                         heap_flags,
                         resource_desc,
                         initial_state,
-                        None,
+                        clear_value,
                         &mut result,
                     )
                 } {

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -140,6 +140,14 @@ impl AllocatorVisualizer {
                             ));
                             ui.text(format!("total block size: {} KiB", total_block_size / 1024));
                             ui.text(format!("total allocated:  {} KiB", total_allocated / 1024));
+                            ui.text(format!(
+                                "num committed resource allocations: {}",
+                                mem_type.committed_allocations.num_allocations
+                            ));
+                            ui.text(format!(
+                                "total committed resource allocations size: {} KiB",
+                                mem_type.committed_allocations.total_size
+                            ));
 
                             let active_block_count = mem_type
                                 .memory_blocks

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -250,8 +250,7 @@ impl AllocatorVisualizer {
                     // Imgui can actually modify this number to be out of bounds, so we will clamp manually.
                     window.bytes_per_unit = window
                         .bytes_per_unit
-                        .min(BYTES_PER_UNIT_MAX)
-                        .max(BYTES_PER_UNIT_MIN);
+                        .clamp(BYTES_PER_UNIT_MAX, BYTES_PER_UNIT_MIN);
 
                     // Draw the visualization in a child window.
                     imgui::ChildWindow::new(&format!(

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -141,11 +141,11 @@ impl AllocatorVisualizer {
                             ui.text(format!("total block size: {} KiB", total_block_size / 1024));
                             ui.text(format!("total allocated:  {} KiB", total_allocated / 1024));
                             ui.text(format!(
-                                "num committed resource allocations: {}",
+                                "committed resource allocations: {}",
                                 mem_type.committed_allocations.num_allocations
                             ));
                             ui.text(format!(
-                                "total committed resource allocations size: {} KiB",
+                                "total committed resource allocations: {} KiB",
                                 mem_type.committed_allocations.total_size
                             ));
 
@@ -250,7 +250,7 @@ impl AllocatorVisualizer {
                     // Imgui can actually modify this number to be out of bounds, so we will clamp manually.
                     window.bytes_per_unit = window
                         .bytes_per_unit
-                        .clamp(BYTES_PER_UNIT_MAX, BYTES_PER_UNIT_MIN);
+                        .clamp(BYTES_PER_UNIT_MIN, BYTES_PER_UNIT_MAX);
 
                     // Draw the visualization in a child window.
                     imgui::ChildWindow::new(&format!(

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -309,7 +309,8 @@ impl AllocatorVisualizer {
     /// - If [`true`], the widget will be drawn and an (X) closing button will be added to the widget bar.
     pub fn render(&mut self, allocator: &Allocator, ui: &imgui::Ui<'_>, opened: Option<&mut bool>) {
         if opened != Some(&mut false) {
-            self.render_breakdown(allocator, ui, opened);
+            self.render_main_window(ui, opened, allocator);
+            self.render_memory_block_windows(ui, allocator);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@
 //!         requirements,
 //!         location: MemoryLocation::CpuToGpu,
 //!         linear: true, // Buffers are always linear
+//!         dedicated_allocation: false,
 //!     }).unwrap();
 //!
 //! // Bind memory to the buffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //!         requirements,
 //!         location: MemoryLocation::CpuToGpu,
 //!         linear: true, // Buffers are always linear
-//!         dedicated_allocation: false,
+//!         allocation_scheme: AllocationScheme::GpuAllocatorManaged,
 //!     }).unwrap();
 //!
 //! // Bind memory to the buffer

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -161,13 +161,13 @@ impl MemoryBlock {
         size: u64,
         mem_type_index: usize,
         mapped: bool,
-        block_type: BlockType,
+        block_type: &BlockType,
         buffer_device_address: bool,
     ) -> Result<Self> {
         let dedicated_allocation = match block_type {
             BlockType::Dedicated {
                 dedicated_allocation,
-            } => dedicated_allocation,
+            } => *dedicated_allocation,
             BlockType::Shared => false,
         };
 
@@ -291,7 +291,7 @@ impl MemoryType {
         let size = desc.requirements.size;
         let alignment = desc.requirements.alignment;
 
-        let block_type = if size > memblock_size {
+        let block_type = if size > memblock_size || desc.dedicated_allocation {
             BlockType::Dedicated {
                 dedicated_allocation: desc.dedicated_allocation,
             }
@@ -306,7 +306,7 @@ impl MemoryType {
                 size,
                 self.memory_type_index,
                 self.mappable,
-                block_type,
+                &block_type,
                 self.buffer_device_address,
             )?;
 
@@ -402,7 +402,7 @@ impl MemoryType {
             memblock_size,
             self.memory_type_index,
             self.mappable,
-            block_type,
+            &block_type,
             self.buffer_device_address,
         )?;
 

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -142,7 +142,6 @@ pub(crate) struct MemoryBlock {
     pub(crate) size: u64,
     pub(crate) mapped_ptr: *mut std::ffi::c_void,
     pub(crate) sub_allocator: Box<dyn allocator::SubAllocator>,
-    pub(crate) dedicated_block: bool,
     pub(crate) dedicated_allocation: bool,
 }
 
@@ -224,7 +223,6 @@ impl MemoryBlock {
             mapped_ptr,
             sub_allocator,
             dedicated_allocation,
-            dedicated_block,
         })
     }
 

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -19,10 +19,10 @@ use crate::{
 pub enum AllocationScheme {
     /// This allocation will be for a buffer, and it will be driver managed using vulkans DedicatedAllocation feature.
     /// The driver will be able to perform optimizations in some cases with this type of allocation.
-    DedicatedBuffer { buffer: *const vk::Buffer },
+    DedicatedBuffer { buffer: vk::Buffer },
     /// This allocation will be for a image, and it will be driver managed using vulkans DedicatedAllocation feature.
     /// The driver will be able to perform optimizations in some cases with this type of allocation.
-    DedicatedImage { image: *const vk::Image },
+    DedicatedImage { image: vk::Image },
     /// This allocation will be managed by the GPU allocator.
     /// It is possible that the allocation will reside in an allocation block shared with other resources.
     GpuAllocatorManaged,
@@ -186,11 +186,11 @@ impl MemoryBlock {
             let mut dedicated_memory_info = vk::MemoryDedicatedAllocateInfo::builder();
             let alloc_info = match allocation_scheme {
                 AllocationScheme::DedicatedBuffer { buffer } => {
-                    dedicated_memory_info = dedicated_memory_info.buffer(unsafe { **buffer });
+                    dedicated_memory_info = dedicated_memory_info.buffer(*buffer);
                     alloc_info.push_next(&mut dedicated_memory_info)
                 }
                 AllocationScheme::DedicatedImage { image } => {
-                    dedicated_memory_info = dedicated_memory_info.image(unsafe { **image });
+                    dedicated_memory_info = dedicated_memory_info.image(*image);
                     alloc_info.push_next(&mut dedicated_memory_info)
                 }
                 AllocationScheme::GpuAllocatorManaged => alloc_info,

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -138,14 +138,9 @@ impl AllocatorVisualizer {
                                             "mapped pointer: 0x{:x}",
                                             block.mapped_ptr as usize
                                         ));
-                                        ui.text(format!(
-                                            "dedicated block: {}",
-                                            block.dedicated_block
-                                        ));
-                                        ui.text(format!(
-                                            "dedicated allocation: {}",
-                                            block.dedicated_allocation
-                                        ));
+                                        if block.dedicated_allocation {
+                                            ui.text(format!("Dedicated Allocation",));
+                                        }
 
                                         block.sub_allocator.draw_base_info(ui);
 

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -139,7 +139,7 @@ impl AllocatorVisualizer {
                                             block.mapped_ptr as usize
                                         ));
                                         if block.dedicated_allocation {
-                                            ui.text(format!("Dedicated Allocation",));
+                                            ui.text("Dedicated Allocation");
                                         }
 
                                         block.sub_allocator.draw_base_info(ui);

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -221,7 +221,7 @@ impl AllocatorVisualizer {
                     // Imgui can actually modify this number to be out of bounds, so we will clamp manually.
                     window.bytes_per_unit = window
                         .bytes_per_unit
-                        .clamp(BYTES_PER_UNIT_MAX, BYTES_PER_UNIT_MIN);
+                        .clamp(BYTES_PER_UNIT_MIN, BYTES_PER_UNIT_MAX);
 
                     // Draw the visualization in a child window.
                     imgui::ChildWindow::new(&format!(

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -221,8 +221,7 @@ impl AllocatorVisualizer {
                     // Imgui can actually modify this number to be out of bounds, so we will clamp manually.
                     window.bytes_per_unit = window
                         .bytes_per_unit
-                        .min(BYTES_PER_UNIT_MAX)
-                        .max(BYTES_PER_UNIT_MIN);
+                        .clamp(BYTES_PER_UNIT_MAX, BYTES_PER_UNIT_MIN);
 
                     // Draw the visualization in a child window.
                     imgui::ChildWindow::new(&format!(

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -138,6 +138,14 @@ impl AllocatorVisualizer {
                                             "mapped pointer: 0x{:x}",
                                             block.mapped_ptr as usize
                                         ));
+                                        ui.text(format!(
+                                            "dedicated block: {}",
+                                            block.dedicated_block
+                                        ));
+                                        ui.text(format!(
+                                            "dedicated allocation: {}",
+                                            block.dedicated_allocation
+                                        ));
 
                                         block.sub_allocator.draw_base_info(ui);
 


### PR DESCRIPTION
### Changes
This PR adds the option to create dedicated allocations in the Vulkan allocator and CommittedResources in the Dx12 allocator. These types of allocations are managed by the driver, which allows it to do special optimizations (🧙‍♂️ magic). 

### Vulkan
In the Vulkan allocator, you must now pass an extra bool `dedicated_allocation` into the `allocate` function. Vulkan 1.1 is required for this to be available, though there is an extension for Vulkan 1.0 available (which I didn't integrate, but I could do that if we want to support it).

The visualizer now displays whether a memory block is backed by a dedicated allocation or not.

### D3D12
In DirectX, dedicated allocations are hidden behind the `CreateCommittedResource()` call. It is not possible to access these allocations, so I've added a `create_resource` function to the dx12 allocator which will return a `Resource` object. You can decide whether you want this to be a `Placed` or `Committed` resource, and the rest is handled under the hood for you. When freeing a resource, you have to call the `free_resource` function on the allocator. 

I have added a special section that displays the total amount of committed resources and their total size per memory type to the visualizer. 

### Testing
I have tested these changes in the dx12 and vulkan backends of the Breda framework. Performance on vulkan and dx12 increased by about 10-fold in our ray-tracing shaders when marking render targets as dedicated resources.