### PR TITLE
d3d12: Remove now-unneeded unsafe `Send`/`Sync` markers for `Allocation` and `MemoryBlock`

### DIFF
--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -39,7 +39,7 @@ pub(crate) trait SubAllocatorBase: crate::visualizer::SubAllocatorVisualizer {}
 #[cfg(not(feature = "visualizer"))]
 pub(crate) trait SubAllocatorBase {}
 
-pub(crate) trait SubAllocator: SubAllocatorBase + std::fmt::Debug {
+pub(crate) trait SubAllocator: SubAllocatorBase + std::fmt::Debug + Sync + Send {
     fn allocate(
         &mut self,
         size: u64,

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -270,9 +270,6 @@ pub struct CommittedAllocationStatistics {
     pub total_size: u64,
 }
 
-unsafe impl Send for Allocation {}
-unsafe impl Sync for Allocation {}
-
 impl Allocation {
     pub fn chunk_id(&self) -> Option<std::num::NonZeroU64> {
         self.chunk_id
@@ -363,9 +360,7 @@ impl MemoryBlock {
     }
 }
 
-unsafe impl Send for MemoryBlock {}
-unsafe impl Sync for MemoryBlock {}
-
+#[derive(Debug)]
 struct MemoryType {
     memory_blocks: Vec<Option<MemoryBlock>>,
     committed_allocations: CommittedAllocationStatistics,
@@ -374,36 +369,6 @@ struct MemoryType {
     heap_properties: D3D12_HEAP_PROPERTIES,
     memory_type_index: usize,
     active_general_blocks: usize,
-}
-
-struct HeapPropertiesDebug(D3D12_HEAP_PROPERTIES);
-
-impl std::fmt::Debug for HeapPropertiesDebug {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("D3D12_HEAP_PROPERTIES")
-            .field("Type", &self.0.Type)
-            .field("CPUPageProperty", &self.0.CPUPageProperty)
-            .field("MemoryPoolPreference", &self.0.MemoryPoolPreference)
-            .field("CreationNodeMask", &self.0.CreationNodeMask)
-            .field("VisibleNodeMask", &self.0.VisibleNodeMask)
-            .finish()
-    }
-}
-
-impl std::fmt::Debug for MemoryType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MemoryType")
-            .field("memory_blocks", &self.memory_blocks)
-            .field("memory_location", &self.memory_location)
-            .field("heap_category", &self.heap_category)
-            .field(
-                "heap_properties",
-                &HeapPropertiesDebug(self.heap_properties),
-            )
-            .field("memory_type_index", &self.memory_type_index)
-            .field("active_general_blocks", &self.active_general_blocks)
-            .finish()
-    }
 }
 
 const DEFAULT_DEVICE_MEMBLOCK_SIZE: u64 = 256 * 1024 * 1024;


### PR DESCRIPTION
Thanks to windows-rs implementing these unsafe markers for COM objects because they are [declared `agile`] (and wrapping the raw pointers in the first place, which are not marked `Send`/`Sync` by the Rust language) we can now let the compiler auto-implement the marker traits.  This'll benefit safety (the traits require `unsafe` for a reason) in case we add fields to these structs that aren't `Send`/`Sync` in the future.

The same should be done for Vulkan at some point, by manually defining `Send`+`Sync` wrapper types around affected fields.

Also clear out `MemoryType`'s `Debug` implementation which is already implemented by windows-rs.

[declared `agile`]: https://github.com/microsoft/win32metadata/issues/740
