### PR TITLE
Configurable allocation sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ let mut allocator = Allocator::new(&AllocatorCreateDesc {
     physical_device,
     debug_settings: Default::default(),
     buffer_device_address: true,  // Ideally, check the BufferDeviceAddressFeatures struct.
+    allocation_sizes: Default::default(),
 });
 ```
 
@@ -78,6 +79,7 @@ use gpu_allocator::d3d12::*;
 let mut allocator = Allocator::new(&AllocatorCreateDesc {
     device,
     debug_settings: Default::default(),
+    allocation_sizes: Default::default(),
 });
 ```
 

--- a/examples/d3d12-buffer-winrs.rs
+++ b/examples/d3d12-buffer-winrs.rs
@@ -90,6 +90,7 @@ fn main() -> Result<()> {
     let mut allocator = Allocator::new(&AllocatorCreateDesc {
         device: device.clone(),
         debug_settings: Default::default(),
+        allocation_sizes: Default::default(),
     })
     .unwrap();
 

--- a/examples/d3d12-buffer.rs
+++ b/examples/d3d12-buffer.rs
@@ -119,6 +119,7 @@ fn main() {
     let mut allocator = Allocator::new(&AllocatorCreateDesc {
         device: device.as_windows().clone(),
         debug_settings: Default::default(),
+        allocation_sizes: Default::default(),
     })
     .unwrap();
 

--- a/examples/d3d12-visualization/main.rs
+++ b/examples/d3d12-visualization/main.rs
@@ -1,5 +1,6 @@
 #![windows_subsystem = "windows"]
 //! Example showcasing [`winapi`] interop with [`gpu-allocator`] which is driven by the [`windows`] crate.
+use gpu_allocator::AllocationSizes;
 use log::info;
 use raw_window_handle::HasRawWindowHandle;
 
@@ -358,6 +359,7 @@ fn main() {
         let mut allocator = Allocator::new(&AllocatorCreateDesc {
             device: device.as_windows().clone(),
             debug_settings: Default::default(),
+            allocation_sizes: Default::default(),
         })
         .unwrap();
 

--- a/examples/d3d12-visualization/main.rs
+++ b/examples/d3d12-visualization/main.rs
@@ -1,6 +1,5 @@
 #![windows_subsystem = "windows"]
 //! Example showcasing [`winapi`] interop with [`gpu-allocator`] which is driven by the [`windows`] crate.
-use gpu_allocator::AllocationSizes;
 use log::info;
 use raw_window_handle::HasRawWindowHandle;
 

--- a/examples/vulkan-buffer.rs
+++ b/examples/vulkan-buffer.rs
@@ -98,6 +98,7 @@ fn main() {
         physical_device: pdevice,
         debug_settings: Default::default(),
         buffer_device_address: false,
+        allocation_sizes: Default::default(),
     })
     .unwrap();
 

--- a/examples/vulkan-visualization/main.rs
+++ b/examples/vulkan-visualization/main.rs
@@ -231,6 +231,7 @@ fn main() -> ash::prelude::VkResult<()> {
             physical_device: pdevice,
             debug_settings: Default::default(),
             buffer_device_address: false,
+            allocation_sizes: Default::default(),
         })
         .unwrap(),
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //!     physical_device,
 //!     debug_settings: Default::default(),
 //!     buffer_device_address: true,  // Ideally, check the BufferDeviceAddressFeatures struct.
+//!     allocation_sizes: Default::default(),
 //! });
 //! # }
 //! # #[cfg(not(feature = "vulkan"))]
@@ -48,6 +49,7 @@
 //! #     physical_device,
 //! #     debug_settings: Default::default(),
 //! #     buffer_device_address: true,  // Ideally, check the BufferDeviceAddressFeatures struct.
+//! #     allocation_sizes: Default::default(),
 //! # }).unwrap();
 //!
 //! // Setup vulkan info
@@ -89,6 +91,7 @@
 //! let mut allocator = Allocator::new(&AllocatorCreateDesc {
 //!     device,
 //!     debug_settings: Default::default(),
+//!     allocation_sizes: Default::default(),
 //! });
 //! # }
 //! # #[cfg(not(feature = "d3d12"))]
@@ -108,6 +111,7 @@
 //! # let mut allocator = Allocator::new(&AllocatorCreateDesc {
 //! #     device: device,
 //! #     debug_settings: Default::default(),
+//! #     allocation_sizes: Default::default(),
 //! # }).unwrap();
 //!
 //! let buffer_desc = Direct3D12::D3D12_RESOURCE_DESC {
@@ -207,6 +211,42 @@ impl Default for AllocatorDebugSettings {
             log_allocations: false,
             log_frees: false,
             log_stack_traces: false,
+        }
+    }
+}
+
+/// The sizes of the memory blocks that the allocator will create.
+///
+/// Useful for tuning the allocator to your application's needs. For example most games will be fine with the default
+/// values, but eg. an app might want to use smaller block sizes to reduce the amount of memory used.
+///
+/// It is recommended to avoid setting the values above 256MB to avoid issues on systems that don't support Resizeable BAR.
+#[derive(Clone, Copy, Debug)]
+pub struct AllocationSizes {
+    /// The size of the memory blocks that will be created for the GPU only memory type.
+    ///
+    /// Defaults to 256MB.
+    device_memblock_size: u64,
+    /// The size of the memory blocks that will be created for the CPU visible memory types.
+    ///
+    /// Defaults to 64MB.
+    host_memblock_size: u64,
+}
+
+impl AllocationSizes {
+    pub fn new(device_memblock_size: u64, host_memblock_size: u64) -> Self {
+        Self {
+            device_memblock_size,
+            host_memblock_size,
+        }
+    }
+}
+
+impl Default for AllocationSizes {
+    fn default() -> Self {
+        Self {
+            device_memblock_size: 256 * 1024 * 1024,
+            host_memblock_size: 64 * 1024 * 1024,
         }
     }
 }

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -12,7 +12,8 @@ use log::{debug, Level};
 use std::fmt;
 
 use crate::{
-    allocator::fmt_bytes, AllocationError, AllocatorDebugSettings, MemoryLocation, Result,
+    allocator::fmt_bytes, AllocationError, AllocationSizes, AllocatorDebugSettings, MemoryLocation,
+    Result,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -60,6 +61,7 @@ pub struct AllocatorCreateDesc {
     pub physical_device: ash::vk::PhysicalDevice,
     pub debug_settings: AllocatorDebugSettings,
     pub buffer_device_address: bool,
+    pub allocation_sizes: AllocationSizes,
 }
 
 #[derive(Debug)]
@@ -269,9 +271,6 @@ pub(crate) struct MemoryType {
     pub(crate) buffer_device_address: bool,
 }
 
-const DEFAULT_DEVICE_MEMBLOCK_SIZE: u64 = 256 * 1024 * 1024;
-const DEFAULT_HOST_MEMBLOCK_SIZE: u64 = 64 * 1024 * 1024;
-
 impl MemoryType {
     fn allocate(
         &mut self,
@@ -279,6 +278,7 @@ impl MemoryType {
         desc: &AllocationCreateDesc<'_>,
         granularity: u64,
         backtrace: Option<backtrace::Backtrace>,
+        allocation_sizes: &AllocationSizes,
     ) -> Result<Allocation> {
         let allocation_type = if desc.linear {
             AllocationType::Linear
@@ -290,9 +290,9 @@ impl MemoryType {
             .memory_properties
             .contains(vk::MemoryPropertyFlags::HOST_VISIBLE)
         {
-            DEFAULT_HOST_MEMBLOCK_SIZE
+            allocation_sizes.host_memblock_size
         } else {
-            DEFAULT_DEVICE_MEMBLOCK_SIZE
+            allocation_sizes.device_memblock_size
         };
 
         let size = desc.requirements.size;
@@ -505,6 +505,7 @@ pub struct Allocator {
     device: ash::Device,
     pub(crate) buffer_image_granularity: u64,
     pub(crate) debug_settings: AllocatorDebugSettings,
+    allocation_sizes: AllocationSizes,
 }
 
 impl fmt::Debug for Allocator {
@@ -621,6 +622,7 @@ impl Allocator {
             device: desc.device.clone(),
             buffer_image_granularity: granularity,
             debug_settings: desc.debug_settings,
+            allocation_sizes: AllocationSizes::default(),
         })
     }
 
@@ -694,6 +696,7 @@ impl Allocator {
                 desc,
                 self.buffer_image_granularity,
                 backtrace.clone(),
+                &self.allocation_sizes,
             )
         };
 
@@ -715,6 +718,7 @@ impl Allocator {
                     desc,
                     self.buffer_image_granularity,
                     backtrace,
+                    &self.allocation_sizes,
                 )
             } else {
                 allocation


### PR DESCRIPTION
This adds an `AllocationSizes` struct to both the Vulkan and DX12 `Allocator` and `AllocatorCreateDesc` which allows users to configure the size of the memory blocks that are created to be suballocated from.

This doesn't currently clamp it to 256MB, which afaik is a problem for systems that don't support Resizable BAR, but I also don't know how to properly detect if someone is or isn't using Resizable BAR.

I also don't know if we need to enforce alignment, and if so what values do we need to use for alignment?

Closes #156 