### PR TITLE
cargo: Bump `windows-rs` to `0.48`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ imgui = { version = "0.10", features = ["tables-api"], optional = true }
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.47"
+version = "0.48"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",
@@ -56,7 +56,7 @@ env_logger = "0.10"
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows]
-version = "0.47"
+version = "0.48"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",


### PR DESCRIPTION
`0.47` got yanked due to unreliable versioning on the `windows-targets` library crate.
