### PR TITLE
Use `PhantomData` in `MappedAllocationSlab` and fix merge

### DIFF
--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -180,7 +180,7 @@ impl Allocation {
     /// [`Slab`]: presser::Slab
     // best to be explicit where the lifetime is coming from since we're doing unsafe things
     // and relying on an inferred liftime type in the PhantomData below
-    #[allow(clippy::needless_lifetimes)] 
+    #[allow(clippy::needless_lifetimes)]
     pub fn try_as_mapped_slab<'a>(&'a mut self) -> Option<MappedAllocationSlab<'a>> {
         let mapped_ptr = self.mapped_ptr()?.cast().as_ptr();
 

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -178,6 +178,9 @@ impl Allocation {
     /// See the note about safety in [the documentation of Allocation][Allocation#safety]
     ///
     /// [`Slab`]: presser::Slab
+    // best to be explicit where the lifetime is coming from since we're doing unsafe things
+    // and relying on an inferred liftime type in the PhantomData below
+    #[allow(clippy::needless_lifetimes)] 
     pub fn try_as_mapped_slab<'a>(&'a mut self) -> Option<MappedAllocationSlab<'a>> {
         let mapped_ptr = self.mapped_ptr()?.cast().as_ptr();
 

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -8,8 +8,8 @@ pub use visualizer::AllocatorVisualizer;
 use super::allocator;
 use super::allocator::AllocationType;
 use ash::vk;
-use log::{debug, Level};
 use core::marker::PhantomData;
+use log::{debug, Level};
 use std::fmt;
 
 use crate::{


### PR DESCRIPTION
Small followup to #138 applying a slight optimisation and fixing a bad auto-merge.