### PR TITLE
d3d12: Use `Device10` `Placed/CommittedResource` functions for Enhanced-Barriers initial Layout

### DIFF
--- a/examples/d3d12-buffer-winrs.rs
+++ b/examples/d3d12-buffer-winrs.rs
@@ -1,6 +1,6 @@
 //! Example showcasing [`gpu-allocator`] with types and functions from the [`windows`] crate.
 use gpu_allocator::d3d12::{
-    AllocationCreateDesc, Allocator, AllocatorCreateDesc, ResourceCategory,
+    AllocationCreateDesc, Allocator, AllocatorCreateDesc, ID3D12DeviceVersion, ResourceCategory,
 };
 use gpu_allocator::MemoryLocation;
 use log::*;
@@ -88,7 +88,7 @@ fn main() -> Result<()> {
 
     // Setting up the allocator
     let mut allocator = Allocator::new(&AllocatorCreateDesc {
-        device: device.clone(),
+        device: ID3D12DeviceVersion::Device(device.clone()),
         debug_settings: Default::default(),
         allocation_sizes: Default::default(),
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,18 +240,25 @@ impl AllocationSizes {
 
         let mut device_memblock_size =
             device_memblock_size.clamp(FOUR_MB, TWO_HUNDRED_AND_FIFTY_SIX_MB);
-        let mut host_memblock_size = host_memblock_size.clamp(FOUR_MB, TWO_HUNDRED_AND_FIFTY_SIX_MB);
+        let mut host_memblock_size =
+            host_memblock_size.clamp(FOUR_MB, TWO_HUNDRED_AND_FIFTY_SIX_MB);
 
         if device_memblock_size % FOUR_MB != 0 {
             let val = device_memblock_size / FOUR_MB + 1;
             device_memblock_size = val * FOUR_MB;
-            log::warn!("Device memory block size must be a multiple of 4MB, clamping to {}MB", device_memblock_size / 1024 / 1024)
+            log::warn!(
+                "Device memory block size must be a multiple of 4MB, clamping to {}MB",
+                device_memblock_size / 1024 / 1024
+            )
         }
-        
+
         if host_memblock_size % FOUR_MB != 0 {
             let val = host_memblock_size / FOUR_MB + 1;
             host_memblock_size = val * FOUR_MB;
-            log::warn!("Host memory block size must be a multiple of 4MB, clamping to {}MB", host_memblock_size / 1024 / 1024)
+            log::warn!(
+                "Host memory block size must be a multiple of 4MB, clamping to {}MB",
+                host_memblock_size / 1024 / 1024
+            )
         }
 
         Self {

--- a/src/result.rs
+++ b/src/result.rs
@@ -14,6 +14,8 @@ pub enum AllocationError {
     InvalidAllocatorCreateDesc(String),
     #[error("Internal error: {0}")]
     Internal(String),
+    #[error("Initial `BARRIER_LAYOUT` needs `Device10`")]
+    BarrierLayoutNeedsDevice10,
 }
 
 pub type Result<V, E = AllocationError> = ::std::result::Result<V, E>;


### PR DESCRIPTION
When using enhanced barriers new resource creation APIs need to be used to set its initial layout rather than setting an initial state, which is the legacy enumeration API.

In order to support this we need access to `Device10` where the new methods reside, which we could query (`.cast()`) from `ID3D12Device` or request from the user directly as done here.
