### PR TITLE
Fix minimal versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 all-features = true
 
 [dependencies]
-log = "0.4"
+log = "0.4.9"
 thiserror = "1.0"
 presser = { version = "0.3" }
 # Only needed for vulkan.  Disable all default features as good practice,


### PR DESCRIPTION
I was trying to compile `bevy` using [`cargo minimal-versions`](https://github.com/taiki-e/cargo-minimal-versions) and noticed that `gpu-allocator` depended on `backtrace 0.3` and `log 0.4`, but actually used features from `backtrace 0.3.3` (`Backtrace::new_unresolved` and `Backtrace::resolve`) and `log 0.4.9` (didn't import the `log!` macro when calling `log::warn!`; could be fixed by importing it too if you prefer it, but looks unnecessary), which made the build fail.