### PR TITLE
🪘 Disable default features on `egui` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ presser = { version = "0.3" }
 # such as the ability to link/load a Vulkan library.
 ash = { version = ">=0.34, <=0.37", optional = true, default-features = false, features = ["debug"] }
 # Only needed for visualizer.
-egui = { version = "0.22", optional = true }
-egui_extras = { version = "0.22", optional = true }
+egui = { version = "0.22", optional = true, default-features = false }
+egui_extras = { version = "0.22", optional = true, default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 # Only needed for public-winapi interop helpers


### PR DESCRIPTION
With the landing of #176 I attempted to integrate the latest release in our codebase, only to be met with a `cargo deny` warning. 

This PR disables the (fully redundant for this lib) default features.