### PR TITLE
Remove unused windowing-related dependencies from `dev-dependencies`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,6 @@ optional = true
 [dev-dependencies]
 # Enable the "loaded" feature to be able to access the Vulkan entrypoint.
 ash = { version = "0.37", default-features = false, features = ["debug", "loaded"] }
-ash-window = "0.12"
-raw-window-handle = "0.5"
-winit = { version = "0.28", features = ["x11", "wayland"] }
 env_logger = "0.10"
 
 [target.'cfg(windows)'.dev-dependencies]


### PR DESCRIPTION
During the `imgui` => `egui` conversion in #176 all window-based examples were removed but none of their dependencies were removed, causing a suspiciously-successful `raw-window-handle 0.6` bump by `dependabot` (#179) despite this being fully incompatible with the current `winit 0.28` release, as well as `ash-window 0.12`.

Delete `winit`, `ash-window` and `raw-window-handle` from the dependency table.
