### PR TITLE
Make backtrace dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,4 +85,4 @@ d3d12 = ["windows"]
 public-winapi = ["dep:winapi"]
 backtrace = ["dep:backtrace"]
 
-default = ["d3d12", "vulkan"]
+default = ["d3d12", "vulkan", "backtrace"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 ]
 
 [dependencies]
-backtrace = "0.3"
+backtrace = { version = "0.3", optional = true }
 log = "0.4"
 thiserror = "1.0"
 presser = { version = "0.3" }
@@ -78,10 +78,11 @@ name = "d3d12-buffer-winrs"
 required-features = ["d3d12"]
 
 [features]
-visualizer = ["egui", "egui_extras"]
+visualizer = ["egui", "egui_extras", "backtrace"]
 vulkan = ["ash"]
 d3d12 = ["windows"]
 # Expose helper functionality for winapi types to interface with gpu-allocator, which is primarily windows-rs driven
 public-winapi = ["dep:winapi"]
+backtrace = ["dep:backtrace"]
 
 default = ["d3d12", "vulkan"]

--- a/src/allocator/dedicated_block_allocator/mod.rs
+++ b/src/allocator/dedicated_block_allocator/mod.rs
@@ -12,7 +12,7 @@ pub(crate) struct DedicatedBlockAllocator {
     size: u64,
     allocated: u64,
     name: Option<String>,
-    backtrace: Option<backtrace::Backtrace>,
+    backtrace: Option<crate::backtrace::Backtrace>,
 }
 
 impl DedicatedBlockAllocator {
@@ -35,7 +35,7 @@ impl SubAllocator for DedicatedBlockAllocator {
         _allocation_type: AllocationType,
         _granularity: u64,
         name: &str,
-        backtrace: Option<backtrace::Backtrace>,
+        backtrace: Option<crate::backtrace::Backtrace>,
     ) -> Result<(u64, std::num::NonZeroU64)> {
         if self.allocated != 0 {
             return Err(AllocationError::OutOfMemory);

--- a/src/allocator/free_list_allocator/mod.rs
+++ b/src/allocator/free_list_allocator/mod.rs
@@ -26,7 +26,7 @@ pub(crate) struct MemoryChunk {
     pub(crate) offset: u64,
     pub(crate) allocation_type: AllocationType,
     pub(crate) name: Option<String>,
-    pub(crate) backtrace: Option<backtrace::Backtrace>, // Only used if STORE_STACK_TRACES is true
+    pub(crate) backtrace: Option<crate::backtrace::Backtrace>, // Only used if STORE_STACK_TRACES is true
     next: Option<std::num::NonZeroU64>,
     prev: Option<std::num::NonZeroU64>,
 }
@@ -156,7 +156,7 @@ impl SubAllocator for FreeListAllocator {
         allocation_type: AllocationType,
         granularity: u64,
         name: &str,
-        backtrace: Option<backtrace::Backtrace>,
+        backtrace: Option<crate::backtrace::Backtrace>,
     ) -> Result<(u64, std::num::NonZeroU64)> {
         let free_size = self.size - self.allocated;
         if size > free_size {

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -32,10 +32,10 @@ pub(crate) struct AllocationReport {
     pub(crate) name: String,
     pub(crate) size: u64,
     #[cfg(feature = "visualizer")]
-    pub(crate) backtrace: Option<backtrace::Backtrace>,
+    pub(crate) backtrace: Option<crate::backtrace::Backtrace>,
 }
 
-pub(crate) fn resolve_backtrace(backtrace: &Option<backtrace::Backtrace>) -> String {
+pub(crate) fn resolve_backtrace(backtrace: &Option<crate::backtrace::Backtrace>) -> String {
     backtrace.as_ref().map_or_else(
         || "".to_owned(),
         |bt| {
@@ -59,7 +59,7 @@ pub(crate) trait SubAllocator: SubAllocatorBase + std::fmt::Debug + Sync + Send 
         allocation_type: AllocationType,
         granularity: u64,
         name: &str,
-        backtrace: Option<backtrace::Backtrace>,
+        backtrace: Option<crate::backtrace::Backtrace>,
     ) -> Result<(u64, std::num::NonZeroU64)>;
 
     fn free(&mut self, chunk_id: Option<std::num::NonZeroU64>) -> Result<()>;

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -1,0 +1,24 @@
+#[cfg(feature = "backtrace")]
+type Backtrace = backtrace::Backtrace;
+
+#[cfg(not(feature = "backtrace"))]
+#[derive(Clone)]
+pub struct Backtrace;
+
+#[cfg(not(feature = "backtrace"))]
+impl Backtrace {
+    pub fn new() -> Self {
+        Self
+    }
+    pub fn new_unresolved() -> Self {
+        Self
+    }
+    pub fn resolve(&mut self) {}
+}
+
+impl core::fmt::Debug for Backtrace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Backtrace(enable the gpu-allocator backtrace feature to get backtraces)")
+            .finish()
+    }
+}

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "backtrace")]
-type Backtrace = backtrace::Backtrace;
+pub type Backtrace = backtrace::Backtrace;
 
 #[cfg(not(feature = "backtrace"))]
 #[derive(Clone)]
@@ -16,6 +16,7 @@ impl Backtrace {
     pub fn resolve(&mut self) {}
 }
 
+#[cfg(not(feature = "backtrace"))]
 impl core::fmt::Debug for Backtrace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Backtrace(enable the gpu-allocator backtrace feature to get backtraces)")

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -421,7 +421,7 @@ impl MemoryType {
         &mut self,
         device: &ID3D12DeviceVersion,
         desc: &AllocationCreateDesc<'_>,
-        backtrace: Option<backtrace::Backtrace>,
+        backtrace: Option<crate::backtrace::Backtrace>,
         allocation_sizes: &AllocationSizes,
     ) -> Result<Allocation> {
         let allocation_type = AllocationType::Linear;
@@ -718,7 +718,7 @@ impl Allocator {
         let alignment = desc.alignment;
 
         let backtrace = if self.debug_settings.store_stack_traces {
-            Some(backtrace::Backtrace::new_unresolved())
+            Some(crate::backtrace::Backtrace::new_unresolved())
         } else {
             None
         };
@@ -729,7 +729,7 @@ impl Allocator {
                 &desc.name, size, alignment
             );
             if self.debug_settings.log_stack_traces {
-                let backtrace = backtrace::Backtrace::new();
+                let backtrace = crate::backtrace::Backtrace::new();
                 debug!("Allocation stack trace: {:?}", &backtrace);
             }
         }
@@ -761,7 +761,7 @@ impl Allocator {
             let name = allocation.name.as_deref().unwrap_or("<null>");
             debug!("Freeing `{}`.", name);
             if self.debug_settings.log_stack_traces {
-                let backtrace = backtrace::Backtrace::new();
+                let backtrace = crate::backtrace::Backtrace::new();
                 debug!("Free stack trace: {:?}", backtrace);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@
 //! # fn main() {}
 //! ```
 
+mod backtrace;
 mod result;
 pub use result::*;
 
@@ -192,6 +193,8 @@ pub struct AllocatorDebugSettings {
     /// Stores a copy of the full backtrace for every allocation made, this makes it easier to debug leaks
     /// or other memory allocations, but storing stack traces has a RAM overhead so should be disabled
     /// in shipping applications.
+    ///
+    /// Only works if the `backtrace` feature is enabled.
     pub store_stack_traces: bool,
     /// Log out every allocation as it's being made with log level Debug, rather spammy so off by default
     pub log_allocations: bool,

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -456,7 +456,7 @@ impl MemoryType {
         device: &ash::Device,
         desc: &AllocationCreateDesc<'_>,
         granularity: u64,
-        backtrace: Option<backtrace::Backtrace>,
+        backtrace: Option<crate::backtrace::Backtrace>,
         allocation_sizes: &AllocationSizes,
     ) -> Result<Allocation> {
         let allocation_type = if desc.linear {
@@ -813,7 +813,7 @@ impl Allocator {
         let alignment = desc.requirements.alignment;
 
         let backtrace = if self.debug_settings.store_stack_traces {
-            Some(backtrace::Backtrace::new_unresolved())
+            Some(crate::backtrace::Backtrace::new_unresolved())
         } else {
             None
         };
@@ -824,7 +824,7 @@ impl Allocator {
                 &desc.name, size, alignment
             );
             if self.debug_settings.log_stack_traces {
-                let backtrace = backtrace::Backtrace::new();
+                let backtrace = crate::backtrace::Backtrace::new();
                 debug!("Allocation stack trace: {:?}", backtrace);
             }
         }
@@ -915,7 +915,7 @@ impl Allocator {
             let name = allocation.name.as_deref().unwrap_or("<null>");
             debug!("Freeing `{}`.", name);
             if self.debug_settings.log_stack_traces {
-                let backtrace = format!("{:?}", backtrace::Backtrace::new());
+                let backtrace = format!("{:?}", crate::backtrace::Backtrace::new());
                 debug!("Free stack trace: {}", backtrace);
             }
         }


### PR DESCRIPTION
I was going through my dependencies, trying to slim down the dependency tree. I saw that `backtrace` depends on `cc`, which might be expensive. So I tried to put backtrace inside a feature that can be turned off.


The results aren't all that impressive though
- I got to shave off around 5 crates for a full recompile. Might translate into 1 second of CI time.
- Maybe a 10 ms reduction in incremental compile times, if anything at all.