### PR TITLE
Use std::backtrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gpu-allocator"
 version = "0.23.0"
 authors = ["Traverse Research <opensource@traverseresearch.nl>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Memory allocator for GPU memory in Vulkan and DirectX 12"
 categories = ["rendering", "rendering::graphics-api"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ include = [
 ]
 
 [dependencies]
-backtrace = "0.3"
 log = "0.4"
 thiserror = "1.0"
 presser = { version = "0.3" }

--- a/examples/vulkan-buffer-backtrace.rs
+++ b/examples/vulkan-buffer-backtrace.rs
@@ -1,0 +1,213 @@
+use ash::vk;
+use log::info;
+
+use std::default::Default;
+use std::ffi::CString;
+
+use gpu_allocator::vulkan::{
+    AllocationCreateDesc, AllocationScheme, Allocator, AllocatorCreateDesc,
+};
+use gpu_allocator::MemoryLocation;
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init();
+
+    let entry = unsafe { ash::Entry::load() }.unwrap();
+
+    // Create Vulkan instance
+    let instance = {
+        let app_name = CString::new("Vulkan gpu-allocator test").unwrap();
+
+        let appinfo = vk::ApplicationInfo::builder()
+            .application_name(&app_name)
+            .application_version(0)
+            .engine_name(&app_name)
+            .engine_version(0)
+            .api_version(vk::make_api_version(0, 1, 0, 0));
+
+        let layer_names = [CString::new("VK_LAYER_KHRONOS_validation").unwrap()];
+        let layers_names_raw: Vec<*const i8> = layer_names
+            .iter()
+            .map(|raw_name| raw_name.as_ptr())
+            .collect();
+
+        let extensions_names_raw = vec![];
+
+        let create_info = vk::InstanceCreateInfo::builder()
+            .application_info(&appinfo)
+            .enabled_layer_names(&layers_names_raw)
+            .enabled_extension_names(&extensions_names_raw);
+
+        unsafe {
+            entry
+                .create_instance(&create_info, None)
+                .expect("Instance creation error")
+        }
+    };
+
+    // Look for vulkan physical device
+    let (pdevice, queue_family_index) = {
+        let pdevices = unsafe {
+            instance
+                .enumerate_physical_devices()
+                .expect("Physical device error")
+        };
+        pdevices
+            .iter()
+            .find_map(|pdevice| {
+                unsafe { instance.get_physical_device_queue_family_properties(*pdevice) }
+                    .iter()
+                    .enumerate()
+                    .find_map(|(index, &info)| {
+                        let supports_graphics = info.queue_flags.contains(vk::QueueFlags::GRAPHICS);
+                        if supports_graphics {
+                            Some((*pdevice, index))
+                        } else {
+                            None
+                        }
+                    })
+            })
+            .expect("Couldn't find suitable device.")
+    };
+
+    // Create vulkan device
+    let device = {
+        let device_extension_names_raw = vec![];
+        let features = vk::PhysicalDeviceFeatures {
+            shader_clip_distance: 1,
+            ..Default::default()
+        };
+        let priorities = [1.0];
+
+        let queue_info = vk::DeviceQueueCreateInfo::builder()
+            .queue_family_index(queue_family_index as u32)
+            .queue_priorities(&priorities);
+
+        let create_info = vk::DeviceCreateInfo::builder()
+            .queue_create_infos(std::slice::from_ref(&queue_info))
+            .enabled_extension_names(&device_extension_names_raw)
+            .enabled_features(&features);
+
+        unsafe { instance.create_device(pdevice, &create_info, None).unwrap() }
+    };
+
+    // Setting up the allocator
+    let mut allocator = Allocator::new(&AllocatorCreateDesc {
+        instance: instance.clone(),
+        device: device.clone(),
+        physical_device: pdevice,
+        debug_settings: gpu_allocator::AllocatorDebugSettings {
+            store_stack_traces: true,
+            log_allocations: true,
+            log_frees: true,
+            log_stack_traces: true,
+            ..Default::default()
+        },
+        buffer_device_address: false,
+        allocation_sizes: Default::default(),
+    })
+    .unwrap();
+
+    // Test allocating Gpu Only memory
+    {
+        let test_buffer_info = vk::BufferCreateInfo::builder()
+            .size(512)
+            .usage(vk::BufferUsageFlags::STORAGE_BUFFER)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE);
+        let test_buffer = unsafe { device.create_buffer(&test_buffer_info, None) }.unwrap();
+        let requirements = unsafe { device.get_buffer_memory_requirements(test_buffer) };
+        let location = MemoryLocation::GpuOnly;
+
+        let allocation = allocator
+            .allocate(&AllocationCreateDesc {
+                requirements,
+                location,
+                linear: true,
+                allocation_scheme: AllocationScheme::GpuAllocatorManaged,
+                name: "Test allocation (Gpu Only)",
+            })
+            .unwrap();
+
+        unsafe {
+            device
+                .bind_buffer_memory(test_buffer, allocation.memory(), allocation.offset())
+                .unwrap()
+        };
+
+        allocator.free(allocation).unwrap();
+
+        unsafe { device.destroy_buffer(test_buffer, None) };
+
+        info!("Allocation and deallocation of GpuOnly memory was successful.");
+    }
+
+    // Test allocating Cpu to Gpu memory
+    {
+        let test_buffer_info = vk::BufferCreateInfo::builder()
+            .size(512)
+            .usage(vk::BufferUsageFlags::STORAGE_BUFFER)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE);
+        let test_buffer = unsafe { device.create_buffer(&test_buffer_info, None) }.unwrap();
+        let requirements = unsafe { device.get_buffer_memory_requirements(test_buffer) };
+        let location = MemoryLocation::CpuToGpu;
+
+        let allocation = allocator
+            .allocate(&AllocationCreateDesc {
+                requirements,
+                location,
+                linear: true,
+                allocation_scheme: AllocationScheme::GpuAllocatorManaged,
+                name: "Test allocation (Cpu to Gpu)",
+            })
+            .unwrap();
+
+        unsafe {
+            device
+                .bind_buffer_memory(test_buffer, allocation.memory(), allocation.offset())
+                .unwrap()
+        };
+
+        allocator.free(allocation).unwrap();
+
+        unsafe { device.destroy_buffer(test_buffer, None) };
+
+        info!("Allocation and deallocation of CpuToGpu memory was successful.");
+    }
+
+    // Test allocating Gpu to Cpu memory
+    {
+        let test_buffer_info = vk::BufferCreateInfo::builder()
+            .size(512)
+            .usage(vk::BufferUsageFlags::STORAGE_BUFFER)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE);
+        let test_buffer = unsafe { device.create_buffer(&test_buffer_info, None) }.unwrap();
+        let requirements = unsafe { device.get_buffer_memory_requirements(test_buffer) };
+        let location = MemoryLocation::GpuToCpu;
+
+        let allocation = allocator
+            .allocate(&AllocationCreateDesc {
+                requirements,
+                location,
+                linear: true,
+                allocation_scheme: AllocationScheme::GpuAllocatorManaged,
+                name: "Test allocation (Gpu to Cpu)",
+            })
+            .unwrap();
+
+        unsafe {
+            device
+                .bind_buffer_memory(test_buffer, allocation.memory(), allocation.offset())
+                .unwrap()
+        };
+
+        allocator.free(allocation).unwrap();
+
+        unsafe { device.destroy_buffer(test_buffer, None) };
+
+        info!("Allocation and deallocation of GpuToCpu memory was successful.");
+    }
+
+    drop(allocator); // Explicitly drop before destruction of device and instance.
+    unsafe { device.destroy_device(None) };
+    unsafe { instance.destroy_instance(None) };
+}

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -5,8 +5,8 @@ pub(crate) use dedicated_block_allocator::DedicatedBlockAllocator;
 
 pub(crate) mod free_list_allocator;
 pub(crate) use free_list_allocator::FreeListAllocator;
-
 use log::*;
+use std::{backtrace::Backtrace, sync::Arc};
 
 #[derive(PartialEq, Copy, Clone, Debug)]
 #[repr(u8)]
@@ -32,18 +32,7 @@ pub(crate) struct AllocationReport {
     pub(crate) name: String,
     pub(crate) size: u64,
     #[cfg(feature = "visualizer")]
-    pub(crate) backtrace: Option<backtrace::Backtrace>,
-}
-
-pub(crate) fn resolve_backtrace(backtrace: &Option<backtrace::Backtrace>) -> String {
-    backtrace.as_ref().map_or_else(
-        || "".to_owned(),
-        |bt| {
-            let mut bt = bt.clone();
-            bt.resolve();
-            format!("{:?}", bt)
-        },
-    )
+    pub(crate) backtrace: Option<Arc<Backtrace>>,
 }
 
 #[cfg(feature = "visualizer")]
@@ -59,7 +48,7 @@ pub(crate) trait SubAllocator: SubAllocatorBase + std::fmt::Debug + Sync + Send 
         allocation_type: AllocationType,
         granularity: u64,
         name: &str,
-        backtrace: Option<backtrace::Backtrace>,
+        backtrace: Option<Arc<Backtrace>>,
     ) -> Result<(u64, std::num::NonZeroU64)>;
 
     fn free(&mut self, chunk_id: Option<std::num::NonZeroU64>) -> Result<()>;

--- a/src/visualizer/allocation_reports.rs
+++ b/src/visualizer/allocation_reports.rs
@@ -1,7 +1,7 @@
 use egui::{Label, Response, Sense, Ui, WidgetText};
 use egui_extras::{Column, TableBuilder};
 
-use crate::allocator::{fmt_bytes, resolve_backtrace, AllocationReport};
+use crate::allocator::{fmt_bytes, AllocationReport};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) enum AllocationReportVisualizeSorting {
@@ -123,7 +123,9 @@ pub(crate) fn render_allocation_reports_ui(
 
                 if backtrace.is_some() {
                     resp.1.on_hover_ui(|ui| {
-                        ui.label(resolve_backtrace(&backtrace));
+                        if let Some(ref backtrace) = backtrace {
+                            ui.label(format!("{}", backtrace));
+                        }
                     });
                 }
 

--- a/src/visualizer/memory_chunks.rs
+++ b/src/visualizer/memory_chunks.rs
@@ -1,6 +1,6 @@
 use egui::{Color32, DragValue, Rect, ScrollArea, Sense, Ui, Vec2};
 
-use crate::allocator::{free_list_allocator::MemoryChunk, resolve_backtrace};
+use crate::allocator::free_list_allocator::MemoryChunk;
 
 use super::ColorScheme;
 
@@ -113,11 +113,10 @@ pub(crate) fn render_memory_chunks_ui<'a>(
                             if let Some(name) = &chunk.name {
                                 ui.label(format!("name: {}", name));
                             }
-                            if settings.show_backtraces && chunk.backtrace.is_some() {
-                                ui.label(format!(
-                                    "backtrace: {}",
-                                    resolve_backtrace(&chunk.backtrace)
-                                ));
+                            if settings.show_backtraces {
+                                if let Some(ref backtrace) = chunk.backtrace {
+                                    ui.label(format!("backtrace: {}", backtrace));
+                                }
                             }
                         });
                     }


### PR DESCRIPTION
Supersedes https://github.com/Traverse-Research/gpu-allocator/pull/183 . I picked `Option<Arc<Backtrace>>`, which shouldn't have any overhead, as long as the backtrace flag is not set.

I also bumped up the Rust edition, since the backtrace was added in Rust 1.65.0, which has been released well after the Rust 2021 edition has been released.