### PR TITLE
bumbed egui and egui_extras to 0.23.0, fixed warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ presser = { version = "0.3" }
 # such as the ability to link/load a Vulkan library.
 ash = { version = ">=0.34, <=0.37", optional = true, default-features = false, features = ["debug"] }
 # Only needed for visualizer.
-egui = { version = "0.22", optional = true, default-features = false }
-egui_extras = { version = "0.22", optional = true, default-features = false }
+egui = { version = "0.23", optional = true, default-features = false }
+egui_extras = { version = "0.23", optional = true, default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 # Only needed for public-winapi interop helpers

--- a/src/visualizer/memory_chunks.rs
+++ b/src/visualizer/memory_chunks.rs
@@ -95,7 +95,7 @@ pub(crate) fn render_memory_chunks_ui<'a>(
                     if ui.is_rect_visible(resp.rect) {
                         ui.painter().rect(
                             resp.rect,
-                            egui::Rounding::none(),
+                            egui::Rounding::ZERO,
                             color_scheme
                                 .get_allocation_type_color(data[cursor_idx].allocation_type),
                             egui::Stroke::new(1.0, Color32::BLACK),


### PR DESCRIPTION
exactly what is on the tin, updated egui and egui_extras to version 0.23.0 as well as updating code to use non deprecated values/functions