### PR TITLE
Replace `backtrace` crate with stabilized `std::backtrace` implementation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -78,7 +78,6 @@ rustflags = [
     # END - Embark standard lints v6 for Rust 1.55+
 
     # Our additional lints
-    "-Wclippy::clone_on_ref_ptr",
     "-Wclippy::cognitive_complexity",
     "-Wclippy::needless_pass_by_value",
     "-Wclippy::option_if_let_else",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,21 @@ jobs:
       - name: Cargo check
         run: cargo check --workspace --all-targets --features ${{ matrix.features }} --no-default-features
 
+  check_msrv:
+    name: Check MSRV (1.65.0)
+    strategy:
+      matrix:
+        include:
+        - os: ubuntu-latest
+          features: vulkan
+        - os: windows-latest
+          features: vulkan,d3d12
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.65.0
+      - run: cargo check --workspace --all-targets --features ${{ matrix.features }} --no-default-features
+
   test:
     name: Test Suite
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/Traverse-Research/gpu-allocator"
 repository = "https://github.com/Traverse-Research/gpu-allocator"
 keywords = ["vulkan", "memory", "allocator"]
 documentation = "https://docs.rs/gpu-allocator/"
+rust-version = "1.65"
 
 include = [
     "/README.md",
@@ -19,7 +20,6 @@ include = [
 ]
 
 [dependencies]
-backtrace = "0.3"
 log = "0.4"
 thiserror = "1.0"
 presser = { version = "0.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gpu-allocator"
 version = "0.24.0"
 authors = ["Traverse Research <opensource@traverseresearch.nl>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Memory allocator for GPU memory in Vulkan and DirectX 12"
 categories = ["rendering", "rendering::graphics-api"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
 [![LICENSE](https://img.shields.io/badge/license-apache-blue.svg?logo=apache)](LICENSE-APACHE)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](../main/CODE_OF_CONDUCT.md)
+[![MSRV](https://img.shields.io/badge/rustc-1.65.0+-ab6000.svg)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
 
 [![Banner](banner.png)](https://traverseresearch.nl)
 
@@ -128,6 +129,10 @@ let hr = unsafe {
 drop(resource);
 allocator.free(allocation).unwrap();
 ```
+
+## Minimum Supported Rust Version
+
+The MSRV for this crate and the `vulkan` and `d3d12` features is Rust 1.65.  Any other features such as the `visualizer` (with all the `egui` dependencies) may have a higher requirement and are not tested in our CI.
 
 ## License
 

--- a/README.tpl
+++ b/README.tpl
@@ -6,6 +6,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
 [![LICENSE](https://img.shields.io/badge/license-apache-blue.svg?logo=apache)](LICENSE-APACHE)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](../main/CODE_OF_CONDUCT.md)
+[![MSRV](https://img.shields.io/badge/rustc-1.65.0+-ab6000.svg)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
 
 [![Banner](banner.png)](https://traverseresearch.nl)
 
@@ -17,6 +18,10 @@ gpu-allocator = "0.24.0"
 ![Visualizer](visualizer.png)
 
 {{readme}}
+
+## Minimum Supported Rust Version
+
+The MSRV for this crate and the `vulkan` and `d3d12` features is Rust 1.65.  Any other features such as the `visualizer` (with all the `egui` dependencies) may have a higher requirement and are not tested in our CI.
 
 ## License
 

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -1,3 +1,7 @@
+use std::{backtrace::Backtrace, sync::Arc};
+
+use log::*;
+
 use crate::result::*;
 
 pub(crate) mod dedicated_block_allocator;
@@ -5,8 +9,6 @@ pub(crate) use dedicated_block_allocator::DedicatedBlockAllocator;
 
 pub(crate) mod free_list_allocator;
 pub(crate) use free_list_allocator::FreeListAllocator;
-
-use log::*;
 
 #[derive(PartialEq, Copy, Clone, Debug)]
 #[repr(u8)]
@@ -32,18 +34,7 @@ pub(crate) struct AllocationReport {
     pub(crate) name: String,
     pub(crate) size: u64,
     #[cfg(feature = "visualizer")]
-    pub(crate) backtrace: Option<backtrace::Backtrace>,
-}
-
-pub(crate) fn resolve_backtrace(backtrace: &Option<backtrace::Backtrace>) -> String {
-    backtrace.as_ref().map_or_else(
-        || "".to_owned(),
-        |bt| {
-            let mut bt = bt.clone();
-            bt.resolve();
-            format!("{:?}", bt)
-        },
-    )
+    pub(crate) backtrace: Arc<Backtrace>,
 }
 
 #[cfg(feature = "visualizer")]
@@ -59,7 +50,7 @@ pub(crate) trait SubAllocator: SubAllocatorBase + std::fmt::Debug + Sync + Send 
         allocation_type: AllocationType,
         granularity: u64,
         name: &str,
-        backtrace: Option<backtrace::Backtrace>,
+        backtrace: Arc<Backtrace>,
     ) -> Result<(u64, std::num::NonZeroU64)>;
 
     fn free(&mut self, chunk_id: Option<std::num::NonZeroU64>) -> Result<()>;

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::unimplemented, clippy::unwrap_used, clippy::ok_expect)]
 
-use std::fmt;
+use std::{backtrace::Backtrace, fmt, sync::Arc};
 
 use log::{debug, warn, Level};
 
@@ -421,7 +421,7 @@ impl MemoryType {
         &mut self,
         device: &ID3D12DeviceVersion,
         desc: &AllocationCreateDesc<'_>,
-        backtrace: Option<backtrace::Backtrace>,
+        backtrace: Arc<Backtrace>,
         allocation_sizes: &AllocationSizes,
     ) -> Result<Allocation> {
         let allocation_type = AllocationType::Linear;
@@ -717,11 +717,11 @@ impl Allocator {
         let size = desc.size;
         let alignment = desc.alignment;
 
-        let backtrace = if self.debug_settings.store_stack_traces {
-            Some(backtrace::Backtrace::new_unresolved())
+        let backtrace = Arc::new(if self.debug_settings.store_stack_traces {
+            Backtrace::force_capture()
         } else {
-            None
-        };
+            Backtrace::disabled()
+        });
 
         if self.debug_settings.log_allocations {
             debug!(
@@ -729,8 +729,8 @@ impl Allocator {
                 &desc.name, size, alignment
             );
             if self.debug_settings.log_stack_traces {
-                let backtrace = backtrace::Backtrace::new();
-                debug!("Allocation stack trace: {:?}", &backtrace);
+                let backtrace = Backtrace::force_capture();
+                debug!("Allocation stack trace: {}", backtrace);
             }
         }
 
@@ -761,8 +761,8 @@ impl Allocator {
             let name = allocation.name.as_deref().unwrap_or("<null>");
             debug!("Freeing `{}`.", name);
             if self.debug_settings.log_stack_traces {
-                let backtrace = backtrace::Backtrace::new();
-                debug!("Free stack trace: {:?}", backtrace);
+                let backtrace = Backtrace::force_capture();
+                debug!("Free stack trace: {}", backtrace);
             }
         }
 

--- a/src/visualizer/allocation_reports.rs
+++ b/src/visualizer/allocation_reports.rs
@@ -1,7 +1,9 @@
+use std::backtrace::BacktraceStatus;
+
 use egui::{Label, Response, Sense, Ui, WidgetText};
 use egui_extras::{Column, TableBuilder};
 
-use crate::allocator::{fmt_bytes, resolve_backtrace, AllocationReport};
+use crate::allocator::{fmt_bytes, AllocationReport};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) enum AllocationReportVisualizeSorting {
@@ -121,9 +123,9 @@ pub(crate) fn render_allocation_reports_ui(
                     ui.label(name);
                 });
 
-                if backtrace.is_some() {
+                if backtrace.status() == BacktraceStatus::Captured {
                     resp.1.on_hover_ui(|ui| {
-                        ui.label(resolve_backtrace(&backtrace));
+                        ui.label(backtrace.to_string());
                     });
                 }
 

--- a/src/visualizer/memory_chunks.rs
+++ b/src/visualizer/memory_chunks.rs
@@ -1,6 +1,8 @@
+use std::backtrace::BacktraceStatus;
+
 use egui::{Color32, DragValue, Rect, ScrollArea, Sense, Ui, Vec2};
 
-use crate::allocator::{free_list_allocator::MemoryChunk, resolve_backtrace};
+use crate::allocator::free_list_allocator::MemoryChunk;
 
 use super::ColorScheme;
 
@@ -113,11 +115,10 @@ pub(crate) fn render_memory_chunks_ui<'a>(
                             if let Some(name) = &chunk.name {
                                 ui.label(format!("name: {}", name));
                             }
-                            if settings.show_backtraces && chunk.backtrace.is_some() {
-                                ui.label(format!(
-                                    "backtrace: {}",
-                                    resolve_backtrace(&chunk.backtrace)
-                                ));
+                            if settings.show_backtraces
+                                && chunk.backtrace.status() == BacktraceStatus::Captured
+                            {
+                                ui.label(chunk.backtrace.to_string());
                             }
                         });
                     }


### PR DESCRIPTION
Sticking to [my promise](https://github.com/Traverse-Research/gpu-allocator/pull/183#issuecomment-1759302163) of updating and submitting this old branch in #183.

Fixes #183 (by no longer using the `backrace`/`cc` crate);
Fixes #184 (the old approach from that branch).

---

Rust 1.65 [stabilized `std::backtrace::Backtrace`], which we can use in place of the `backtrace` crate to reduce our dependency stack.

Normally `Backtrace::capture()` would listen to the `RUST_BACKTRACE` and `RUST_LIB_BACKTRACE` environment variables, but this is unsuitable for us as capturing backtraces is configured via boolean debug feature flags in the `AllocatorDebugSettings` struct.  Fortunately `Backtrace::force_capture()` exists which circumvents these env var checks and always returns a backtrace, and is hence used in the codebase here.


Unfortuantely the type no longer implements `Clone` like `backtrace::Backtrace`, requiring us to wrap it in an `Arc` (because most of our types are thread-safe) to clone the `Backtrace` around various (sub)allocations and statistics reports.

[stabilized `std::backtrace::Backtrace`]: https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#stabilized-apis
