### PR TITLE
Allow `windows 0.52` in addition to `windows 0.51`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,21 +3,6 @@ on: [push, pull_request]
 name: CI
 
 jobs:
-  check:
-    name: Check
-    strategy:
-      matrix:
-        include:
-        - os: ubuntu-latest
-          features: vulkan,visualizer
-        - os: windows-latest
-          features: vulkan,visualizer,d3d12,public-winapi
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Cargo check
-        run: cargo check --workspace --all-targets --features ${{ matrix.features }} --no-default-features
-
   check_msrv:
     name: Check MSRV (1.65.0)
     strategy:
@@ -72,6 +57,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Cargo clippy
         run: cargo clippy --workspace --all-targets --features ${{ matrix.features }} --no-default-features -- -D warnings
+
+      - name: Install nightly Rust
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Generate lockfile with minimal dependency versions
+        run: cargo +nightly generate-lockfile -Zminimal-versions
+      - name: Cargo clippy with minimal-versions
+        run: cargo +stable clippy --workspace --all-targets --features ${{ matrix.features }} --no-default-features -- -D warnings
 
   doc:
     name: Build documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ egui_extras = { version = "0.23", optional = true, default-features = false }
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.51"
+version = ">=0.51,<=0.52"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",
@@ -55,7 +55,7 @@ env_logger = "0.10"
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows]
-version = "0.51"
+version = ">=0.51,<=0.52"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",


### PR DESCRIPTION
Extend the version range bound to allow both as there do not appear to be breaking changes that affect this crate, and test compatibility against the minimum and maximum version of all dependencies in CI.

Also remove the `check` job from CI which is only running a subset of what `clippy` is already also doing.
