### PR TITLE
Enable all features in docs builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ include = [
     "/examples",
 ]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 log = "0.4"
 thiserror = "1.0"


### PR DESCRIPTION
Right now we are only showing vulkan docs in docs.rs while we should also be showing the dx12 ones