### PR TITLE
🆙 Update egui and friends to v0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ presser = { version = "0.3" }
 # such as the ability to link/load a Vulkan library.
 ash = { version = ">=0.34, <=0.37", optional = true, default-features = false, features = ["debug"] }
 # Only needed for visualizer.
-egui = { version = "0.24", optional = true, default-features = false }
-egui_extras = { version = "0.24", optional = true, default-features = false }
+egui = { version = "0.25", optional = true, default-features = false }
+egui_extras = { version = "0.25", optional = true, default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 # Only needed for public-winapi interop helpers


### PR DESCRIPTION
Supersedes #195 and #196

Updates the `egui` and friends to the latest release, v0.25.