### PR TITLE
👨‍🔬Total memory in Allocation Breakdown

### DIFF
--- a/src/visualizer/allocation_reports.rs
+++ b/src/visualizer/allocation_reports.rs
@@ -37,9 +37,13 @@ pub(crate) fn render_allocation_reports_ui(
         .enumerate()
         .filter(|(_, report)| report.name.to_lowercase().contains(&breakdown_filter))
         .collect::<Vec<_>>();
+    let total_size_under_filter: u64 = allocations.iter().map(|a| a.1.size).sum();
+
+    ui.horizontal(|ui| {
+        ui.label(format!("Total: {}", fmt_bytes(total_size_under_filter)));
+    });
 
     let row_height = ui.text_style_height(&egui::TextStyle::Body);
-
     let table = TableBuilder::new(ui)
         .striped(true)
         .resizable(true)

--- a/src/visualizer/allocation_reports.rs
+++ b/src/visualizer/allocation_reports.rs
@@ -39,9 +39,7 @@ pub(crate) fn render_allocation_reports_ui(
         .collect::<Vec<_>>();
     let total_size_under_filter: u64 = allocations.iter().map(|a| a.1.size).sum();
 
-    ui.horizontal(|ui| {
-        ui.label(format!("Total: {}", fmt_bytes(total_size_under_filter)));
-    });
+    ui.label(format!("Total: {}", fmt_bytes(total_size_under_filter)));
 
     let row_height = ui.text_style_height(&egui::TextStyle::Body);
     let table = TableBuilder::new(ui)


### PR DESCRIPTION
We've had this feature previously but it got nerf'd during our transition from egui to imgui. It's small but super useful to be able to see the total amount of memory under various filters (or just the total when no filter is applied).