### PR TITLE
cargo: Bump `windows` crate range to `0.53-0.57`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ metal = { version = "0.28.0", git = "https://github.com/gfx-rs/metal-rs", rev = 
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = ">=0.53,<=0.54"
+version = ">=0.53,<=0.56"
 features = [
     "Win32_Graphics_Direct3D12",
     "Win32_Graphics_Dxgi_Common",
@@ -57,7 +57,7 @@ env_logger = "0.10"
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows]
-version = ">=0.53,<=0.54"
+version = ">=0.53,<=0.56"
 features = [
     "Win32_Graphics_Direct3D",
     "Win32_Graphics_Direct3D12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,7 @@ winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "
 [target.'cfg(windows)'.dependencies.windows]
 version = ">=0.53,<=0.54"
 features = [
-    "Win32_Foundation",
-    "Win32_Graphics",
-    "Win32_Graphics_Direct3D",
     "Win32_Graphics_Direct3D12",
-    "Win32_Graphics_Dxgi",
     "Win32_Graphics_Dxgi_Common",
 ]
 optional = true
@@ -63,11 +59,8 @@ winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", 
 [target.'cfg(windows)'.dev-dependencies.windows]
 version = ">=0.53,<=0.54"
 features = [
-    "Win32_Foundation",
-    "Win32_Graphics",
     "Win32_Graphics_Direct3D",
     "Win32_Graphics_Direct3D12",
-    "Win32_Graphics_Dxgi",
     "Win32_Graphics_Dxgi_Common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ metal = { version = "0.28.0", git = "https://github.com/gfx-rs/metal-rs", rev = 
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = ">=0.51,<=0.52"
+version = ">=0.53,<=0.54"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",
@@ -61,7 +61,7 @@ env_logger = "0.10"
 winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", "winerror", "impl-default", "impl-debug", "winuser", "windowsx", "libloaderapi"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows]
-version = ">=0.51,<=0.52"
+version = ">=0.53,<=0.54"
 features = [
     "Win32_Foundation",
     "Win32_Graphics",

--- a/examples/d3d12-buffer-winrs.rs
+++ b/examples/d3d12-buffer-winrs.rs
@@ -4,7 +4,7 @@ use gpu_allocator::d3d12::{
 };
 use gpu_allocator::MemoryLocation;
 use log::*;
-use windows::core::{ComInterface, Result};
+use windows::core::{Interface, Result};
 use windows::Win32::{
     Foundation::E_NOINTERFACE,
     Graphics::{

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -256,9 +256,8 @@ impl std::ops::Deref for ID3D12DeviceVersion {
     fn deref(&self) -> &Self::Target {
         match self {
             Self::Device(device) => device,
-            // Windows-rs hides CanInto, we know that Device10/Device12 is a subclass of Device but there's not even a Deref.
-            Self::Device10(device10) => windows::core::CanInto::can_into(device10),
-            Self::Device12(device12) => windows::core::CanInto::can_into(device12),
+            Self::Device10(device10) => device10.into(),
+            Self::Device12(device12) => device12.into(),
         }
     }
 }


### PR DESCRIPTION
Allow `windows 0.53` all the way up to and including `0.57` to be used, and remove some unused features from the core crate.