### PR TITLE
Make `metal` dependency rely on the `metal` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ all-features = true
 log = "0.4"
 thiserror = "1.0"
 presser = { version = "0.3" }
-# Only needed for vulkan.  Disable all default features as good practice,
+# Only needed for Vulkan.  Disable all default features as good practice,
 # such as the ability to link/load a Vulkan library.
 ash = { version = ">=0.34, <=0.37", optional = true, default-features = false, features = ["debug"] }
 # Only needed for visualizer.
@@ -34,7 +34,7 @@ egui = { version = ">=0.24, <=0.27", optional = true, default-features = false }
 egui_extras = { version = ">=0.24, <=0.27", optional = true, default-features = false }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-metal = { version = "0.27.0", default-features = false, features = ["link", "dispatch",] }
+metal = { version = "0.27.0", default-features = false, features = ["link", "dispatch"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 # Only needed for public-winapi interop helpers
@@ -88,10 +88,10 @@ name = "metal-buffer"
 required-features = ["metal"]
 
 [features]
-visualizer = ["egui", "egui_extras"]
-vulkan = ["ash"]
-d3d12 = ["windows"]
-metal = []
+visualizer = ["dep:egui", "dep:egui_extras"]
+vulkan = ["dep:ash"]
+d3d12 = ["dep:windows"]
+metal = ["dep:metal"]
 # Expose helper functionality for winapi types to interface with gpu-allocator, which is primarily windows-rs driven
 public-winapi = ["dep:winapi"]
 

--- a/release.toml
+++ b/release.toml
@@ -6,6 +6,6 @@ sign-tag = true
 publish = false
 
 pre-release-replacements = [
-  {file="README.md", search="gpu-allocator = .*", replace="{{crate_name}} = \"{{version}}\""},
-  {file="README.tpl", search="gpu-allocator = .*", replace="{{crate_name}} = \"{{version}}\""},
+  { file = "README.md", search = "gpu-allocator = .*", replace = "{{crate_name}} = \"{{version}}\"" },
+  { file = "README.tpl", search = "gpu-allocator = .*", replace = "{{crate_name}} = \"{{version}}\"" },
 ]

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -35,34 +35,34 @@ impl Allocation {
         let resource =
             self.heap
                 .new_buffer_with_offset(self.size, self.heap.resource_options(), self.offset);
-        resource.map_or(None, |resource| {
+        if let Some(resource) = &resource {
             if let Some(name) = &self.name {
                 resource.set_label(name);
             }
-            Some(resource)
-        })
+        }
+        resource
     }
 
     pub fn make_texture(&self, desc: &metal::TextureDescriptor) -> Option<metal::Texture> {
         let resource = self.heap.new_texture_with_offset(desc, self.offset);
-        resource.map_or(None, |resource| {
+        if let Some(resource) = &resource {
             if let Some(name) = &self.name {
                 resource.set_label(name);
             }
-            Some(resource)
-        })
+        }
+        resource
     }
 
     pub fn make_acceleration_structure(&self) -> Option<metal::AccelerationStructure> {
         let resource = self
             .heap
             .new_acceleration_structure_with_size_offset(self.size, self.offset);
-        resource.map_or(None, |resource| {
+        if let Some(resource) = &resource {
             if let Some(name) = &self.name {
                 resource.set_label(name);
             }
-            Some(resource)
-        })
+        }
+        resource
     }
 
     fn is_null(&self) -> bool {

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -2,8 +2,7 @@
 use std::{backtrace::Backtrace, sync::Arc};
 
 use crate::{
-    allocator::{self, AllocationType},
-    AllocationError, AllocationSizes, AllocatorDebugSettings, MemoryLocation, Result,
+    allocator, AllocationError, AllocationSizes, AllocatorDebugSettings, MemoryLocation, Result,
 };
 use log::{debug, Level};
 use metal::MTLStorageMode;
@@ -36,43 +35,34 @@ impl Allocation {
         let resource =
             self.heap
                 .new_buffer_with_offset(self.size, self.heap.resource_options(), self.offset);
-        resource.map_or_else(
-            || None,
-            |resource| {
-                if let Some(name) = &self.name {
-                    resource.set_label(name);
-                }
-                Some(resource)
-            },
-        )
+        resource.map_or(None, |resource| {
+            if let Some(name) = &self.name {
+                resource.set_label(name);
+            }
+            Some(resource)
+        })
     }
 
     pub fn make_texture(&self, desc: &metal::TextureDescriptor) -> Option<metal::Texture> {
         let resource = self.heap.new_texture_with_offset(desc, self.offset);
-        resource.map_or_else(
-            || None,
-            |resource| {
-                if let Some(name) = &self.name {
-                    resource.set_label(name);
-                }
-                Some(resource)
-            },
-        )
+        resource.map_or(None, |resource| {
+            if let Some(name) = &self.name {
+                resource.set_label(name);
+            }
+            Some(resource)
+        })
     }
 
     pub fn make_acceleration_structure(&self) -> Option<metal::AccelerationStructure> {
         let resource = self
             .heap
             .new_acceleration_structure_with_size_offset(self.size, self.offset);
-        resource.map_or_else(
-            || None,
-            |resource| {
-                if let Some(name) = &self.name {
-                    resource.set_label(name);
-                }
-                Some(resource)
-            },
-        )
+        resource.map_or(None, |resource| {
+            if let Some(name) = &self.name {
+                resource.set_label(name);
+            }
+            Some(resource)
+        })
     }
 
     fn is_null(&self) -> bool {
@@ -203,7 +193,7 @@ impl MemoryType {
         backtrace: Arc<Backtrace>,
         allocation_sizes: &AllocationSizes,
     ) -> Result<Allocation> {
-        let allocation_type = AllocationType::Linear;
+        let allocation_type = allocator::AllocationType::Linear;
 
         let memblock_size = if self.heap_properties.storage_mode() == MTLStorageMode::Private {
             allocation_sizes.device_memblock_size

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -5,7 +5,6 @@ use crate::{
     allocator, AllocationError, AllocationSizes, AllocatorDebugSettings, MemoryLocation, Result,
 };
 use log::{debug, Level};
-use metal::MTLStorageMode;
 
 fn memory_location_to_metal(location: MemoryLocation) -> metal::MTLResourceOptions {
     match location {
@@ -105,10 +104,10 @@ impl<'a> AllocationCreateDesc<'a> {
         Self {
             name,
             location: match desc.storage_mode() {
-                MTLStorageMode::Shared | MTLStorageMode::Managed | MTLStorageMode::Memoryless => {
-                    MemoryLocation::Unknown
-                }
-                MTLStorageMode::Private => MemoryLocation::GpuOnly,
+                metal::MTLStorageMode::Shared
+                | metal::MTLStorageMode::Managed
+                | metal::MTLStorageMode::Memoryless => MemoryLocation::Unknown,
+                metal::MTLStorageMode::Private => MemoryLocation::GpuOnly,
             },
             size: size_and_align.size,
             alignment: size_and_align.align,
@@ -195,7 +194,8 @@ impl MemoryType {
     ) -> Result<Allocation> {
         let allocation_type = allocator::AllocationType::Linear;
 
-        let memblock_size = if self.heap_properties.storage_mode() == MTLStorageMode::Private {
+        let memblock_size = if self.heap_properties.storage_mode() == metal::MTLStorageMode::Private
+        {
             allocation_sizes.device_memblock_size
         } else {
             allocation_sizes.host_memblock_size

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -10,7 +10,7 @@ use std::{backtrace::Backtrace, fmt, marker::PhantomData, sync::Arc};
 use ash::vk;
 use log::{debug, Level};
 
-use super::allocator::{self, AllocationType};
+use super::allocator;
 use crate::{
     allocator::fmt_bytes, AllocationError, AllocationSizes, AllocatorDebugSettings, MemoryLocation,
     Result,
@@ -459,9 +459,9 @@ impl MemoryType {
         allocation_sizes: &AllocationSizes,
     ) -> Result<Allocation> {
         let allocation_type = if desc.linear {
-            AllocationType::Linear
+            allocator::AllocationType::Linear
         } else {
-            AllocationType::NonLinear
+            allocator::AllocationType::NonLinear
         };
 
         let memblock_size = if self


### PR DESCRIPTION
We seem to have this weird case where the `metal` crate is always included (on supported target OSes), even if the non-default `metal` feature isn't turned on.  Found this while wondering why `cargo` wasn't complaining about a clash thanks to the implicit feature created by an optional crate with an identically-named feature in the `[features]` table without [the `dep:` rename prefix], turns out that the `metal` crate wasn't `optional = true` in the first place.  Fix that.

[the `dep:` rename prefix]: https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies
