### PR TITLE
🚦 Allow `egui 0.27`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ presser = { version = "0.3" }
 # such as the ability to link/load a Vulkan library.
 ash = { version = ">=0.34, <=0.37", optional = true, default-features = false, features = ["debug"] }
 # Only needed for visualizer.
-egui = { version = ">=0.24, <=0.26", optional = true, default-features = false }
-egui_extras = { version = ">=0.24, <=0.26", optional = true, default-features = false }
+egui = { version = ">=0.24, <=0.27", optional = true, default-features = false }
+egui_extras = { version = ">=0.24, <=0.27", optional = true, default-features = false }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 metal = { version = "0.27.0", default-features = false, features = ["link", "dispatch",] }

--- a/src/visualizer/allocation_reports.rs
+++ b/src/visualizer/allocation_reports.rs
@@ -51,7 +51,7 @@ pub(crate) fn render_allocation_reports_ui(
 
     fn header_button(ui: &mut Ui, label: &str) -> Response {
         let label = WidgetText::from(label).strong();
-        let label = Label::new(label.strong()).sense(Sense::click());
+        let label = Label::new(label).sense(Sense::click());
         ui.add(label)
     }
 


### PR DESCRIPTION
Supersedes #216 and #217

This PR allows crates using this crate to additionally use egui version 0.27. I also noticed a duplicate call which I removed as a drive-by.