### PR TITLE
d3d12: Add support for castable formats on resource allocations

### DIFF
--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -4,7 +4,10 @@ use std::{backtrace::Backtrace, fmt, sync::Arc};
 
 use log::{debug, warn, Level};
 
-use windows::Win32::{Foundation::E_OUTOFMEMORY, Graphics::{Direct3D12::*, Dxgi::Common::DXGI_FORMAT}};
+use windows::Win32::{
+    Foundation::E_OUTOFMEMORY,
+    Graphics::{Direct3D12::*, Dxgi::Common::DXGI_FORMAT},
+};
 
 #[cfg(feature = "public-winapi")]
 mod public_winapi {
@@ -934,7 +937,7 @@ impl Allocator {
                             if !desc.castable_formats.is_empty() {
                                 warn!("Requesting castable formats, but this feature requires ID3D12Device10");
                             }
-                            
+
                             device.CreatePlacedResource(
                                 allocation.heap(),
                                 allocation.offset(),

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -813,10 +813,7 @@ impl Allocator {
         }
     }
 
-    fn d3d12_resource_desc_1(
-        desc: &D3D12_RESOURCE_DESC,
-        sampler_feedback_mip_region: D3D12_MIP_REGION,
-    ) -> D3D12_RESOURCE_DESC1 {
+    fn d3d12_resource_desc_1(desc: &D3D12_RESOURCE_DESC) -> D3D12_RESOURCE_DESC1 {
         D3D12_RESOURCE_DESC1 {
             Dimension: desc.Dimension,
             Alignment: desc.Alignment,
@@ -829,7 +826,7 @@ impl Allocator {
             Layout: desc.Layout,
             Flags: desc.Flags,
             // TODO: This is the only new field
-            SamplerFeedbackMipRegion: sampler_feedback_mip_region,
+            SamplerFeedbackMipRegion: D3D12_MIP_REGION::default(),
         }
     }
 
@@ -845,8 +842,7 @@ impl Allocator {
                 device.GetResourceAllocationInfo(0, &[*desc.resource_desc])
             },
             ID3D12DeviceVersion::Device12(device) => unsafe {
-                let resource_desc1 =
-                    Self::d3d12_resource_desc_1(desc.resource_desc, D3D12_MIP_REGION::default());
+                let resource_desc1 = Self::d3d12_resource_desc_1(desc.resource_desc);
 
                 let resource_descs = &[resource_desc1];
 
@@ -910,10 +906,7 @@ impl Allocator {
                             ResourceStateOrBarrierLayout::BarrierLayout(initial_layout),
                             ID3D12DeviceVersion::Device10(device),
                         ) => {
-                            let resource_desc1 = Self::d3d12_resource_desc_1(
-                                desc.resource_desc,
-                                D3D12_MIP_REGION::default(),
-                            );
+                            let resource_desc1 = Self::d3d12_resource_desc_1(desc.resource_desc);
 
                             device.CreateCommittedResource3(
                                 *heap_properties,
@@ -930,10 +923,7 @@ impl Allocator {
                             ResourceStateOrBarrierLayout::BarrierLayout(initial_layout),
                             ID3D12DeviceVersion::Device12(device),
                         ) => {
-                            let resource_desc1 = Self::d3d12_resource_desc_1(
-                                desc.resource_desc,
-                                D3D12_MIP_REGION::default(),
-                            );
+                            let resource_desc1 = Self::d3d12_resource_desc_1(desc.resource_desc);
 
                             device.CreateCommittedResource3(
                                 *heap_properties,
@@ -1022,10 +1012,7 @@ impl Allocator {
                             ResourceStateOrBarrierLayout::BarrierLayout(initial_layout),
                             ID3D12DeviceVersion::Device10(device),
                         ) => {
-                            let resource_desc1 = Self::d3d12_resource_desc_1(
-                                desc.resource_desc,
-                                D3D12_MIP_REGION::default(),
-                            );
+                            let resource_desc1 = Self::d3d12_resource_desc_1(desc.resource_desc);
                             device.CreatePlacedResource2(
                                 allocation.heap(),
                                 allocation.offset(),
@@ -1040,10 +1027,7 @@ impl Allocator {
                             ResourceStateOrBarrierLayout::BarrierLayout(initial_layout),
                             ID3D12DeviceVersion::Device12(device),
                         ) => {
-                            let resource_desc1 = Self::d3d12_resource_desc_1(
-                                desc.resource_desc,
-                                D3D12_MIP_REGION::default(),
-                            );
+                            let resource_desc1 = Self::d3d12_resource_desc_1(desc.resource_desc);
                             device.CreatePlacedResource2(
                                 allocation.heap(),
                                 allocation.offset(),

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -246,7 +246,7 @@ pub enum ID3D12DeviceVersion {
     /// Required for enhanced barrier support, i.e. when using
     /// [`ResourceStateOrBarrierLayout::BarrierLayout`].
     Device10(ID3D12Device10),
-    /// Required for castable formats support
+    /// Required for castable formats support, requires the use of enhanced barrier
     Device12(ID3D12Device12),
 }
 
@@ -891,8 +891,8 @@ impl Allocator {
                     desc.clear_value.map(|v| -> *const _ { v });
 
                 if let Err(e) = unsafe {
-                    match (&self.device, desc.initial_state_or_layout) {
-                        (device, ResourceStateOrBarrierLayout::ResourceState(initial_state)) => {
+                    match (desc.initial_state_or_layout, &self.device) {
+                        (ResourceStateOrBarrierLayout::ResourceState(initial_state), device) => {
                             if !desc.castable_formats.is_empty() {
                                 warn!("Requesting castable formats, but this feature requires ID3D12Device12");
                             }
@@ -907,8 +907,8 @@ impl Allocator {
                             )
                         }
                         (
-                            ID3D12DeviceVersion::Device10(device),
                             ResourceStateOrBarrierLayout::BarrierLayout(initial_layout),
+                            ID3D12DeviceVersion::Device10(device),
                         ) => {
                             let resource_desc1 = Self::d3d12_resource_desc_1(
                                 desc.resource_desc,
@@ -927,8 +927,8 @@ impl Allocator {
                             )
                         }
                         (
-                            ID3D12DeviceVersion::Device12(device),
                             ResourceStateOrBarrierLayout::BarrierLayout(initial_layout),
+                            ID3D12DeviceVersion::Device12(device),
                         ) => {
                             let resource_desc1 = Self::d3d12_resource_desc_1(
                                 desc.resource_desc,
@@ -1003,8 +1003,8 @@ impl Allocator {
 
                 let mut result: Option<ID3D12Resource> = None;
                 if let Err(e) = unsafe {
-                    match (&self.device, desc.initial_state_or_layout) {
-                        (device, ResourceStateOrBarrierLayout::ResourceState(initial_state)) => {
+                    match (desc.initial_state_or_layout, &self.device) {
+                        (ResourceStateOrBarrierLayout::ResourceState(initial_state), device) => {
                             if !desc.castable_formats.is_empty() {
                                 warn!("Requesting castable formats, but this feature requires ID3D12Device12");
                             }
@@ -1019,8 +1019,8 @@ impl Allocator {
                             )
                         }
                         (
-                            ID3D12DeviceVersion::Device10(device),
                             ResourceStateOrBarrierLayout::BarrierLayout(initial_layout),
+                            ID3D12DeviceVersion::Device10(device),
                         ) => {
                             let resource_desc1 = Self::d3d12_resource_desc_1(
                                 desc.resource_desc,
@@ -1037,8 +1037,8 @@ impl Allocator {
                             )
                         }
                         (
-                            ID3D12DeviceVersion::Device12(device),
                             ResourceStateOrBarrierLayout::BarrierLayout(initial_layout),
+                            ID3D12DeviceVersion::Device12(device),
                         ) => {
                             let resource_desc1 = Self::d3d12_resource_desc_1(
                                 desc.resource_desc,

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -246,7 +246,7 @@ pub enum ID3D12DeviceVersion {
     /// Required for enhanced barrier support, i.e. when using
     /// [`ResourceStateOrBarrierLayout::BarrierLayout`].
     Device10(ID3D12Device10),
-    /// Required for castable formats support, requires the use of enhanced barrier
+    /// Required for castable formats support, implies use of enhanced barriers
     Device12(ID3D12Device12),
 }
 

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -1058,20 +1058,10 @@ impl Allocator {
                             ID3D12DeviceVersion::Device10(device),
                             ResourceStateOrBarrierLayout::BarrierLayout(initial_layout),
                         ) => {
-                            let resource_desc1 = D3D12_RESOURCE_DESC1 {
-                                Dimension: desc.resource_desc.Dimension,
-                                Alignment: desc.resource_desc.Alignment,
-                                Width: desc.resource_desc.Width,
-                                Height: desc.resource_desc.Height,
-                                DepthOrArraySize: desc.resource_desc.DepthOrArraySize,
-                                MipLevels: desc.resource_desc.MipLevels,
-                                Format: desc.resource_desc.Format,
-                                SampleDesc: desc.resource_desc.SampleDesc,
-                                Layout: desc.resource_desc.Layout,
-                                Flags: desc.resource_desc.Flags,
-                                // TODO: This is the only new field
-                                SamplerFeedbackMipRegion: D3D12_MIP_REGION::default(),
-                            };
+                            let resource_desc1 = Self::d3d12_resource_desc_1(
+                                desc.resource_desc,
+                                D3D12_MIP_REGION::default(),
+                            );
                             device.CreatePlacedResource2(
                                 allocation.heap(),
                                 allocation.offset(),
@@ -1086,20 +1076,10 @@ impl Allocator {
                             ID3D12DeviceVersion::Device12(device),
                             ResourceStateOrBarrierLayout::BarrierLayout(initial_layout),
                         ) => {
-                            let resource_desc1 = D3D12_RESOURCE_DESC1 {
-                                Dimension: desc.resource_desc.Dimension,
-                                Alignment: desc.resource_desc.Alignment,
-                                Width: desc.resource_desc.Width,
-                                Height: desc.resource_desc.Height,
-                                DepthOrArraySize: desc.resource_desc.DepthOrArraySize,
-                                MipLevels: desc.resource_desc.MipLevels,
-                                Format: desc.resource_desc.Format,
-                                SampleDesc: desc.resource_desc.SampleDesc,
-                                Layout: desc.resource_desc.Layout,
-                                Flags: desc.resource_desc.Flags,
-                                // TODO: This is the only new field
-                                SamplerFeedbackMipRegion: D3D12_MIP_REGION::default(),
-                            };
+                            let resource_desc1 = Self::d3d12_resource_desc_1(
+                                desc.resource_desc,
+                                D3D12_MIP_REGION::default(),
+                            );
                             device.CreatePlacedResource2(
                                 allocation.heap(),
                                 allocation.offset(),

--- a/src/result.rs
+++ b/src/result.rs
@@ -14,7 +14,7 @@ pub enum AllocationError {
     InvalidAllocatorCreateDesc(String),
     #[error("Internal error: {0}")]
     Internal(String),
-    #[error("Initial `BARRIER_LAYOUT` needs `Device10`")]
+    #[error("Initial `BARRIER_LAYOUT` needs at least `Device10`")]
     BarrierLayoutNeedsDevice10,
 }
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -16,6 +16,10 @@ pub enum AllocationError {
     Internal(String),
     #[error("Initial `BARRIER_LAYOUT` needs at least `Device10`")]
     BarrierLayoutNeedsDevice10,
+    #[error("Castable formats require enhanced barriers")]
+    CastableFormatsRequiresEnhancedBarriers,
+    #[error("Castable formats require at least `Device12`")]
+    CastableFormatsRequiresAtLeastDevice12,
 }
 
 pub type Result<V, E = AllocationError> = ::std::result::Result<V, E>;


### PR DESCRIPTION
This feature has a dependency on `ID3D12Device12` due to the need of using `GetResourceAllocationInfo3`.
The PR is a draft because I'm still figuring out castable formats support on VK and Metal. 
From early research it looks like VK won't require any change in gpu-allocator as it's mainly achieved through a combination of `VK_IMAGE_CREATE_` bitflags which are outside of the scope of the allocator and handled on application side.

Metal is still being figured out.