### PR TITLE
Add a public API to expose allocation reports

### DIFF
--- a/src/allocator/dedicated_block_allocator/mod.rs
+++ b/src/allocator/dedicated_block_allocator/mod.rs
@@ -116,6 +116,7 @@ impl SubAllocator for DedicatedBlockAllocator {
                 .name
                 .clone()
                 .unwrap_or_else(|| "<Unnamed Dedicated allocation>".to_owned()),
+            offset: 0,
             size: self.size,
             #[cfg(feature = "visualizer")]
             backtrace: self.backtrace.clone(),

--- a/src/allocator/free_list_allocator/mod.rs
+++ b/src/allocator/free_list_allocator/mod.rs
@@ -398,6 +398,7 @@ impl SubAllocator for FreeListAllocator {
                     .name
                     .clone()
                     .unwrap_or_else(|| "<Unnamed FreeList allocation>".to_owned()),
+                offset: chunk.offset,
                 size: chunk.size,
                 #[cfg(feature = "visualizer")]
                 backtrace: chunk.backtrace.clone(),

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -1,4 +1,4 @@
-use std::{backtrace::Backtrace, sync::Arc};
+use std::{backtrace::Backtrace, fmt, ops::Range, sync::Arc};
 
 use log::*;
 
@@ -29,20 +29,73 @@ impl AllocationType {
     }
 }
 
+/// Describes an allocation in the [`AllocatorReport`].
 #[derive(Clone)]
-pub(crate) struct AllocationReport {
-    pub(crate) name: String,
-    pub(crate) size: u64,
+pub struct AllocationReport {
+    /// The name provided to the `allocate()` function.
+    pub name: String,
+    /// The offset in bytes of the allocation in its memory block.
+    pub offset: u64,
+    /// The size in bytes of the allocation.
+    pub size: u64,
     #[cfg(feature = "visualizer")]
     pub(crate) backtrace: Arc<Backtrace>,
 }
+
+/// Describes a memory block in the [`AllocatorReport`].
+#[derive(Clone)]
+pub struct MemoryBlockReport {
+    /// The size in bytes of this memory block.
+    pub size: u64,
+    /// The range of allocations in [`AllocatorReport::allocations`] that are associated
+    /// to this memory block.
+    pub allocations: Range<usize>,
+}
+
+/// A report that can be generated for informational purposes using `Allocator::generate_report()`.
+#[derive(Clone)]
+pub struct AllocatorReport {
+    /// All live allocations, sub-allocated from memory blocks.
+    pub allocations: Vec<AllocationReport>,
+    /// All memory blocks.
+    pub blocks: Vec<MemoryBlockReport>,
+    /// Sum of the memory used by all allocations, in bytes.
+    pub total_allocated_bytes: u64,
+    /// Sum of the memory reserved by all memory blocks including unallocated regions, in bytes.
+    pub total_reserved_bytes: u64,
+}
+
+impl fmt::Debug for AllocationReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = if !self.name.is_empty() { self.name.as_str() } else { "--" };
+        write!(f, "{name:?}: {}", fmt_bytes(self.size))
+    }
+}
+
+impl fmt::Debug for AllocatorReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut allocations = self.allocations.clone();
+        allocations.sort_by_key(|alloc| std::cmp::Reverse(alloc.size));
+
+        let max_num_allocations_to_print = f.precision().unwrap_or(usize::MAX);
+        allocations.truncate(max_num_allocations_to_print);
+
+        f.debug_struct("AllocatorReport")
+            .field("summary", &std::format_args!("{} / {}", fmt_bytes(self.total_allocated_bytes), fmt_bytes(self.total_reserved_bytes)))
+            .field("blocks", &self.blocks.len())
+            .field("allocations", &self.allocations.len())
+            .field("largest", &allocations.as_slice())
+            .finish()
+    }
+}
+
 
 #[cfg(feature = "visualizer")]
 pub(crate) trait SubAllocatorBase: crate::visualizer::SubAllocatorVisualizer {}
 #[cfg(not(feature = "visualizer"))]
 pub(crate) trait SubAllocatorBase {}
 
-pub(crate) trait SubAllocator: SubAllocatorBase + std::fmt::Debug + Sync + Send {
+pub(crate) trait SubAllocator: SubAllocatorBase + fmt::Debug + Sync + Send {
     fn allocate(
         &mut self,
         size: u64,
@@ -81,8 +134,6 @@ pub(crate) trait SubAllocator: SubAllocatorBase + std::fmt::Debug + Sync + Send 
         self.allocated() == 0
     }
 }
-
-pub(crate) const VISUALIZER_TABLE_MAX_ENTRY_NAME_LEN: usize = 40;
 
 pub(crate) fn fmt_bytes(mut amount: u64) -> String {
     const SUFFIX: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -67,7 +67,11 @@ pub struct AllocatorReport {
 
 impl fmt::Debug for AllocationReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let name = if !self.name.is_empty() { self.name.as_str() } else { "--" };
+        let name = if !self.name.is_empty() {
+            self.name.as_str()
+        } else {
+            "--"
+        };
         write!(f, "{name:?}: {}", fmt_bytes(self.size))
     }
 }
@@ -81,14 +85,20 @@ impl fmt::Debug for AllocatorReport {
         allocations.truncate(max_num_allocations_to_print);
 
         f.debug_struct("AllocatorReport")
-            .field("summary", &std::format_args!("{} / {}", fmt_bytes(self.total_allocated_bytes), fmt_bytes(self.total_reserved_bytes)))
+            .field(
+                "summary",
+                &std::format_args!(
+                    "{} / {}",
+                    fmt_bytes(self.total_allocated_bytes),
+                    fmt_bytes(self.total_reserved_bytes)
+                ),
+            )
             .field("blocks", &self.blocks.len())
             .field("allocations", &self.allocations.len())
             .field("largest", &allocations.as_slice())
             .finish()
     }
 }
-
 
 #[cfg(feature = "visualizer")]
 pub(crate) trait SubAllocatorBase: crate::visualizer::SubAllocatorVisualizer {}

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -88,8 +88,8 @@ use super::allocator;
 use super::allocator::AllocationType;
 
 use crate::{
-    allocator::fmt_bytes, AllocationError, AllocationSizes, AllocatorDebugSettings, MemoryLocation,
-    Result,
+    allocator::{AllocatorReport, MemoryBlockReport},
+    AllocationError, AllocationSizes, AllocatorDebugSettings, MemoryLocation, Result,
 };
 
 /// [`ResourceCategory`] is used for supporting [`D3D12_RESOURCE_HEAP_TIER_1`].
@@ -1102,50 +1102,38 @@ impl Allocator {
             Ok(())
         }
     }
+
+    pub fn generate_report(&self) -> AllocatorReport {
+        let mut allocations = vec![];
+        let mut blocks = vec![];
+        let mut total_reserved_bytes = 0;
+
+        for memory_type in &self.memory_types {
+            for block in memory_type.memory_blocks.iter().flatten() {
+                total_reserved_bytes += block.size;
+                let first_allocation = allocations.len();
+                allocations.extend(block.sub_allocator.report_allocations());
+                blocks.push(MemoryBlockReport {
+                    size: block.size,
+                    allocations: first_allocation..allocations.len(),
+                });
+            }
+        }
+
+        let total_allocated_bytes = allocations.iter().map(|report| report.size).sum();
+
+        AllocatorReport {
+            allocations,
+            blocks,
+            total_allocated_bytes,
+            total_reserved_bytes,
+        }
+    }
 }
 
 impl fmt::Debug for Allocator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut allocation_report = vec![];
-        let mut total_reserved_size_in_bytes = 0;
-
-        for memory_type in &self.memory_types {
-            for block in memory_type.memory_blocks.iter().flatten() {
-                total_reserved_size_in_bytes += block.size;
-                allocation_report.extend(block.sub_allocator.report_allocations())
-            }
-        }
-
-        let total_used_size_in_bytes = allocation_report.iter().map(|report| report.size).sum();
-
-        allocation_report.sort_by_key(|alloc| std::cmp::Reverse(alloc.size));
-
-        writeln!(
-            f,
-            "================================================================",
-        )?;
-        writeln!(
-            f,
-            "ALLOCATION BREAKDOWN ({} / {})",
-            fmt_bytes(total_used_size_in_bytes),
-            fmt_bytes(total_reserved_size_in_bytes),
-        )?;
-
-        let max_num_allocations_to_print = f.precision().map_or(usize::MAX, |n| n);
-        for (idx, alloc) in allocation_report.iter().enumerate() {
-            if idx >= max_num_allocations_to_print {
-                break;
-            }
-            writeln!(
-                f,
-                "{:max_len$.max_len$}\t- {}",
-                alloc.name,
-                fmt_bytes(alloc.size),
-                max_len = allocator::VISUALIZER_TABLE_MAX_ENTRY_NAME_LEN,
-            )?;
-        }
-
-        Ok(())
+        self.generate_report().fmt(f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ pub use result::*;
 
 pub(crate) mod allocator;
 
-pub use allocator::{AllocatorReport, AllocationReport, MemoryBlockReport};
+pub use allocator::{AllocationReport, AllocatorReport, MemoryBlockReport};
 
 #[cfg(feature = "visualizer")]
 pub mod visualizer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,8 @@ pub use result::*;
 
 pub(crate) mod allocator;
 
+pub use allocator::{AllocatorReport, AllocationReport, MemoryBlockReport};
+
 #[cfg(feature = "visualizer")]
 pub mod visualizer;
 

--- a/src/visualizer/allocation_reports.rs
+++ b/src/visualizer/allocation_reports.rs
@@ -115,6 +115,7 @@ pub(crate) fn render_allocation_reports_ui(
                     name,
                     size,
                     backtrace,
+                    ..
                 } = alloc;
 
                 row.col(|ui| {


### PR DESCRIPTION
This PR adds a public API that exposes enough information for users to build something like the block visualizer without the egui integration. It also adds an offset field in the allocation report.

I would like to integrate (and expose in some form) this in wgpu to debug memory leaks.

The report could expose more information (for example properties of the memory and stack traces) and I haven't added any documentation yet, but it's a good basis for discussing whether the project is OK with exposing something like this and whether the approach is good.