### PR TITLE
cargo: Replace `metal-rs` patch with `git` dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,6 @@ jobs:
           # is also unmaintained for 4 years depends on malloc_buf >=0.0,<0.1.0,
           # allowing the 0.0.6 release to be used (but not the 1.0.0 release).
           cargo update -p malloc_buf --precise 0.0.6
-          # Force 0.1.2, as older versions use the broken `gcc` crate
-          cargo update -p objc_exception --precise 0.1.2
       - name: Cargo clippy with minimal-versions
         run: cargo +stable clippy --workspace --all-targets --features ${{ matrix.features }} --no-default-features -- -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ egui = { version = ">=0.24, <=0.27", optional = true, default-features = false }
 egui_extras = { version = ">=0.24, <=0.27", optional = true, default-features = false }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-metal = { version = "0.27.0", default-features = false, features = ["link", "dispatch"], optional = true }
+metal = { version = "0.28.0", git = "https://github.com/gfx-rs/metal-rs", rev = "0d6214f", default-features = false, features = ["link", "dispatch"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 # Only needed for public-winapi interop helpers
@@ -96,6 +96,3 @@ metal = ["dep:metal"]
 public-winapi = ["dep:winapi"]
 
 default = ["d3d12", "vulkan"]
-
-[patch.crates-io]
-metal = { git = "https://github.com/Traverse-Research/metal-rs", rev = "a354c33" }

--- a/examples/d3d12-buffer.rs
+++ b/examples/d3d12-buffer.rs
@@ -106,7 +106,7 @@ fn main() {
             )
         };
 
-        assert_eq!(hr, winerror::S_OK, "Failed to create DXGI factory",);
+        assert_eq!(hr, winerror::S_OK, "Failed to create DXGI factory");
         dxgi_factory
     };
 

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -105,7 +105,7 @@ pub struct AllocatorCreateDesc {
 /// let my_gpu_data: Vec<MyGpuData> = make_vertex_data();
 /// ```
 ///
-/// Depending on how the data we're copying will be used, the vulkan device may have a minimum
+/// Depending on how the data we're copying will be used, the Vulkan device may have a minimum
 /// alignment requirement for that data:
 ///
 /// ```ignore
@@ -180,7 +180,7 @@ impl Allocation {
     ///
     /// [`Slab`]: presser::Slab
     // best to be explicit where the lifetime is coming from since we're doing unsafe things
-    // and relying on an inferred liftime type in the PhantomData below
+    // and relying on an inferred lifetime type in the PhantomData below
     #[allow(clippy::needless_lifetimes)]
     pub fn try_as_mapped_slab<'a>(&'a mut self) -> Option<MappedAllocationSlab<'a>> {
         let mapped_ptr = self.mapped_ptr()?.cast().as_ptr();


### PR DESCRIPTION
`gpu-allocator` is a library crate, meaning that `[patch]`es don't get applied when users depend on our crate, and falsely end up with a broken build while our CI said everything was hunky dory ( https://github.com/Traverse-Research/gpu-allocator/issues/224).  Even though we cannot normally have a direct `git` dependency as that blocks us from publishing to crates.io, the current `gpu-allocator` release (though only for Metal) is broken anyway.  It's relying on functionality that has just now been merged upstream, but still has to make it into a (followup patch) release.

What's worse, the harcoded hash that this was pointing to no longer has a live reference on our fork (maybe due to a force-push), and the CI is now failing to to fetch that commit by hash while build-testing `gpu-allocator`.

Let's bump to a `git` dependency for now, and replace that as soon as we have a workable solution, however that pans out.
