### PR TITLE
🦀 Fix Rust 1.78 lints

### DIFF
--- a/examples/d3d12-buffer.rs
+++ b/examples/d3d12-buffer.rs
@@ -68,11 +68,11 @@ fn create_d3d12_device(
                         )
                     };
                     match hr {
-                        winapi::shared::winerror::S_OK => {
+                        winerror::S_OK => {
                             info!("Using D3D12 feature level: {}.", feature_level_name);
                             Some(device)
                         }
-                        winapi::shared::winerror::E_NOINTERFACE => {
+                        winerror::E_NOINTERFACE => {
                             error!("ID3D12Device interface not supported.");
                             None
                         }
@@ -106,11 +106,7 @@ fn main() {
             )
         };
 
-        assert_eq!(
-            hr,
-            winapi::shared::winerror::S_OK,
-            "Failed to create DXGI factory",
-        );
+        assert_eq!(hr, winerror::S_OK, "Failed to create DXGI factory",);
         dxgi_factory
     };
 

--- a/src/allocator/dedicated_block_allocator/mod.rs
+++ b/src/allocator/dedicated_block_allocator/mod.rs
@@ -122,10 +122,6 @@ impl SubAllocator for DedicatedBlockAllocator {
         }]
     }
 
-    fn size(&self) -> u64 {
-        self.size
-    }
-
     fn allocated(&self) -> u64 {
         self.allocated
     }

--- a/src/allocator/free_list_allocator/mod.rs
+++ b/src/allocator/free_list_allocator/mod.rs
@@ -405,10 +405,6 @@ impl SubAllocator for FreeListAllocator {
             .collect::<Vec<_>>()
     }
 
-    fn size(&self) -> u64 {
-        self.size
-    }
-
     fn allocated(&self) -> u64 {
         self.allocated
     }

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -73,15 +73,7 @@ pub(crate) trait SubAllocator: SubAllocatorBase + std::fmt::Debug + Sync + Send 
     #[must_use]
     fn supports_general_allocations(&self) -> bool;
     #[must_use]
-    fn size(&self) -> u64;
-    #[must_use]
     fn allocated(&self) -> u64;
-
-    /// Helper function: reports how much memory is available in this suballocator
-    #[must_use]
-    fn available_memory(&self) -> u64 {
-        self.size() - self.allocated()
-    }
 
     /// Helper function: reports if the suballocator is empty (meaning, having no allocations).
     #[must_use]

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -271,12 +271,16 @@ pub struct AllocatorCreateDesc {
 }
 
 pub enum ResourceType<'a> {
-    /// Allocation equivalent to Dx12's CommittedResource.
+    /// Create a D3D12 [`CommittedResource`].
+    ///
+    /// [`CommittedResource`]: https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12device-createcommittedresource
     Committed {
         heap_properties: &'a D3D12_HEAP_PROPERTIES,
         heap_flags: D3D12_HEAP_FLAGS,
     },
-    /// Allocation equivalent to Dx12's PlacedResource.
+    /// Create a D3D12 [`PlacedResource`].
+    ///
+    /// [`PlacedResource`]: https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12device-createplacedresource
     Placed,
 }
 

--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -92,7 +92,7 @@ impl AllocatorVisualizer {
                             let mut total_allocated = 0;
 
                             for block in mem_type.memory_blocks.iter().flatten() {
-                                total_block_size += block.sub_allocator.size();
+                                total_block_size += block.size;
                                 total_allocated += block.sub_allocator.allocated();
                             }
 
@@ -134,10 +134,7 @@ impl AllocatorVisualizer {
                                 let Some(block) = block else { continue };
 
                                 ui.collapsing(format!("Block: {}", block_idx), |ui| {
-                                    ui.label(format!(
-                                        "size: {} KiB",
-                                        block.sub_allocator.size() / 1024
-                                    ));
+                                    ui.label(format!("size: {} KiB", block.size / 1024));
                                     ui.label(format!(
                                         "allocated: {} KiB",
                                         block.sub_allocator.allocated() / 1024
@@ -205,7 +202,7 @@ impl AllocatorVisualizer {
                         "Memory type {}, Memory block {}, Block size: {} KiB",
                         window.memory_type_index,
                         window.block_index,
-                        memblock.sub_allocator.size() / 1024
+                        memblock.size / 1024
                     ));
 
                     window

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -58,7 +58,7 @@ unsafe impl Sync for SendSyncPtr {}
 pub struct AllocatorCreateDesc {
     pub instance: ash::Instance,
     pub device: ash::Device,
-    pub physical_device: ash::vk::PhysicalDevice,
+    pub physical_device: vk::PhysicalDevice,
     pub debug_settings: AllocatorDebugSettings,
     pub buffer_device_address: bool,
     pub allocation_sizes: AllocationSizes,
@@ -737,7 +737,7 @@ impl fmt::Debug for Allocator {
 
 impl Allocator {
     pub fn new(desc: &AllocatorCreateDesc) -> Result<Self> {
-        if desc.physical_device == ash::vk::PhysicalDevice::null() {
+        if desc.physical_device == vk::PhysicalDevice::null() {
             return Err(AllocationError::InvalidAllocatorCreateDesc(
                 "AllocatorCreateDesc field `physical_device` is null.".into(),
             ));


### PR DESCRIPTION
Rust 1.78 is again a bit more strict and better at finding `unused_qualifications` and `dead_code`.  Solve those, and clean up some documentation while at it.
