### PR TITLE
Fix Rust 1.79 lints

### DIFF
--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -144,7 +144,7 @@ impl AllocatorVisualizer {
 
                                     if block.sub_allocator.supports_visualization()
                                         && ui.button("visualize").clicked()
-                                        && !self.selected_blocks.iter().enumerate().any(|(_, x)| {
+                                        && !self.selected_blocks.iter().any(|x| {
                                             x.memory_type_index == mem_type_idx
                                                 && x.block_index == block_idx
                                         })

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -87,7 +87,7 @@ impl<'a> AllocationCreateDesc<'a> {
         name: &'a str,
         length: u64,
         location: MemoryLocation,
-    ) -> AllocationCreateDesc<'a> {
+    ) -> Self {
         let size_and_align =
             device.heap_buffer_size_and_align(length, memory_location_to_metal(location));
         Self {
@@ -98,11 +98,7 @@ impl<'a> AllocationCreateDesc<'a> {
         }
     }
 
-    pub fn texture(
-        device: &metal::Device,
-        name: &'a str,
-        desc: &metal::TextureDescriptor,
-    ) -> AllocationCreateDesc<'a> {
+    pub fn texture(device: &metal::Device, name: &'a str, desc: &metal::TextureDescriptor) -> Self {
         let size_and_align = device.heap_texture_size_and_align(desc);
         Self {
             name,
@@ -122,7 +118,7 @@ impl<'a> AllocationCreateDesc<'a> {
         name: &'a str,
         size: u64,
         location: MemoryLocation,
-    ) -> AllocationCreateDesc<'a> {
+    ) -> Self {
         let size_and_align = device.heap_acceleration_structure_size_and_align_with_size(size);
         Self {
             name,

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -121,7 +121,7 @@ impl AllocatorVisualizer {
 
                                     if block.sub_allocator.supports_visualization()
                                         && ui.button("visualize").clicked()
-                                        && !self.selected_blocks.iter().enumerate().any(|(_, x)| {
+                                        && !self.selected_blocks.iter().any(|x| {
                                             x.memory_type_index == mem_type_idx
                                                 && x.block_index == block_idx
                                         })


### PR DESCRIPTION
Besides our automerge not caring for a successful CI before merging the latest PR in, this addresses some broken code pointed out by the latest rust 1.79 `clippy`.
