### PR TITLE
Fix `render_memory_block_window`

### DIFF
--- a/src/d3d12/visualizer.rs
+++ b/src/d3d12/visualizer.rs
@@ -173,7 +173,7 @@ impl AllocatorVisualizer {
     ) {
         egui::Window::new("Allocator Memory Blocks")
             .open(open)
-            .show(ctx, |ui| self.render_breakdown_ui(ui, allocator));
+            .show(ctx, |ui| self.render_memory_block_ui(ui, allocator));
     }
 
     pub fn render_memory_block_visualization_windows(

--- a/src/vulkan/visualizer.rs
+++ b/src/vulkan/visualizer.rs
@@ -150,7 +150,7 @@ impl AllocatorVisualizer {
     ) {
         egui::Window::new("Allocator Memory Blocks")
             .open(open)
-            .show(ctx, |ui| self.render_breakdown_ui(ui, allocator));
+            .show(ctx, |ui| self.render_memory_block_ui(ui, allocator));
     }
 
     pub fn render_memory_block_visualization_windows(


### PR DESCRIPTION
`render_memory_block_window ` was calling `render_breakdown_ui` instead of `render_memory_block_ui`.

Resolves #238