### PR TITLE
Upgrade `metal` crate from `git` to released `0.29` on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ egui = { version = ">=0.24, <=0.27", optional = true, default-features = false }
 egui_extras = { version = ">=0.24, <=0.27", optional = true, default-features = false }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-metal = { version = "0.28.0", git = "https://github.com/gfx-rs/metal-rs", rev = "0d6214f", default-features = false, features = ["link", "dispatch"], optional = true }
+metal = { version = "0.29.0", default-features = false, features = ["link", "dispatch"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 # Only needed for public-winapi interop helpers


### PR DESCRIPTION
All our changes were merged upstream and finally made it into the `0.29` release on crates.io, via https://github.com/gfx-rs/metal-rs/pull/327.
