### PR TITLE
✂️ metal: Qualified use cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ allocator.free(allocation).unwrap();
 
 ```rust
 use gpu_allocator::metal::*;
-use objc2_metal as metal;
 let mut allocator = Allocator::new(&AllocatorCreateDesc {
     device: device.clone(),
     debug_settings: Default::default(),
@@ -146,7 +145,6 @@ let mut allocator = Allocator::new(&AllocatorCreateDesc {
 ```rust
 use gpu_allocator::metal::*;
 use gpu_allocator::MemoryLocation;
-use objc2_metal as metal;
 let allocation_desc = AllocationCreateDesc::buffer(
     &device,
     "Example allocation",

--- a/examples/metal-buffer.rs
+++ b/examples/metal-buffer.rs
@@ -1,9 +1,11 @@
 use gpu_allocator::metal::{AllocationCreateDesc, Allocator, AllocatorCreateDesc};
 use log::info;
-use metal::MTLDevice as _;
 use objc2::rc::Id;
 use objc2_foundation::NSArray;
-use objc2_metal as metal;
+use objc2_metal::{
+    MTLCreateSystemDefaultDevice, MTLDevice as _, MTLPixelFormat,
+    MTLPrimitiveAccelerationStructureDescriptor, MTLStorageMode, MTLTextureDescriptor,
+};
 
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init();
@@ -14,7 +16,7 @@ fn main() {
     extern "C" {}
 
     let device =
-        unsafe { Id::from_raw(metal::MTLCreateSystemDefaultDevice()) }.expect("No MTLDevice found");
+        unsafe { Id::from_raw(MTLCreateSystemDefaultDevice()) }.expect("No MTLDevice found");
 
     // Setting up the allocator
     let mut allocator = Allocator::new(&AllocatorCreateDesc {
@@ -68,11 +70,11 @@ fn main() {
 
     // Test allocating texture
     {
-        let texture_desc = unsafe { metal::MTLTextureDescriptor::new() };
-        texture_desc.setPixelFormat(metal::MTLPixelFormat::RGBA8Unorm);
+        let texture_desc = unsafe { MTLTextureDescriptor::new() };
+        texture_desc.setPixelFormat(MTLPixelFormat::RGBA8Unorm);
         unsafe { texture_desc.setWidth(64) };
         unsafe { texture_desc.setHeight(64) };
-        texture_desc.setStorageMode(metal::MTLStorageMode::Private);
+        texture_desc.setStorageMode(MTLStorageMode::Private);
         let allocation_desc =
             AllocationCreateDesc::texture(&device, "Test allocation (Texture)", &texture_desc);
         let allocation = allocator.allocate(&allocation_desc).unwrap();
@@ -84,7 +86,7 @@ fn main() {
     // Test allocating acceleration structure
     {
         let empty_array = NSArray::from_slice(&[]);
-        let acc_desc = metal::MTLPrimitiveAccelerationStructureDescriptor::descriptor();
+        let acc_desc = MTLPrimitiveAccelerationStructureDescriptor::descriptor();
         acc_desc.setGeometryDescriptors(Some(&empty_array));
         let sizes = device.accelerationStructureSizesWithDescriptor(&acc_desc);
         let allocation_desc = AllocationCreateDesc::acceleration_structure_with_size(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,8 +163,7 @@
 //! # fn main() {
 //! use gpu_allocator::metal::*;
 //! # use objc2::rc::Id;
-//! use objc2_metal as metal;
-//! # let device = unsafe { metal::MTLCreateSystemDefaultDevice() };
+//! # let device = unsafe { objc2_metal::MTLCreateSystemDefaultDevice() };
 //! # let device = unsafe { Id::from_raw(device) }.expect("No MTLDevice found");
 //! let mut allocator = Allocator::new(&AllocatorCreateDesc {
 //!     device: device.clone(),
@@ -183,8 +182,7 @@
 //! use gpu_allocator::metal::*;
 //! use gpu_allocator::MemoryLocation;
 //! # use objc2::rc::Id;
-//! use objc2_metal as metal;
-//! # let device = unsafe { metal::MTLCreateSystemDefaultDevice() };
+//! # let device = unsafe { objc2_metal::MTLCreateSystemDefaultDevice() };
 //! # let device = unsafe { Id::from_raw(device) }.expect("No MTLDevice found");
 //! # let mut allocator = Allocator::new(&AllocatorCreateDesc {
 //! #     device: device.clone(),


### PR DESCRIPTION
Some items are imported in scope with `as _` and then again referenced using fully-qualified syntax.  Clean that up, and drop the `use objc2_metal as metal` rename while at it.

Turns out Mac's aren't good at pushing code after all because this was scheduled to be part of the previous PR, but somehow missed out.