### PR TITLE
🦋 metal: Remove inconsistent descriptor creators from `Allocation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,15 @@ let allocation_desc = AllocationCreateDesc::buffer(
     MemoryLocation::GpuOnly,
 );
 let allocation = allocator.allocate(&allocation_desc).unwrap();
-let resource = allocation.make_buffer().unwrap();
+let heap = unsafe { allocation.heap() };
+let resource = unsafe {
+    heap.newBufferWithLength_options_offset(
+        allocation.size() as usize,
+        heap.resourceOptions(),
+        allocation.offset() as usize,
+    )
+}
+.unwrap();
 
 // Cleanup
 drop(resource);

--- a/examples/metal-buffer.rs
+++ b/examples/metal-buffer.rs
@@ -3,7 +3,7 @@ use log::info;
 use objc2::rc::Id;
 use objc2_foundation::NSArray;
 use objc2_metal::{
-    MTLCreateSystemDefaultDevice, MTLDevice as _, MTLPixelFormat,
+    MTLCreateSystemDefaultDevice, MTLDevice as _, MTLHeap, MTLPixelFormat,
     MTLPrimitiveAccelerationStructureDescriptor, MTLStorageMode, MTLTextureDescriptor,
 };
 
@@ -35,7 +35,17 @@ fn main() {
             gpu_allocator::MemoryLocation::GpuOnly,
         );
         let allocation = allocator.allocate(&allocation_desc).unwrap();
-        let _buffer = allocation.make_buffer().unwrap();
+        // SAFETY: We will only allocate objects on this heap within the returned offset and size
+        let heap = unsafe { allocation.heap() };
+        let buffer = unsafe {
+            heap.newBufferWithLength_options_offset(
+                allocation.size() as usize,
+                heap.resourceOptions(),
+                allocation.offset() as usize,
+            )
+        }
+        .unwrap();
+        drop(buffer);
         allocator.free(&allocation).unwrap();
         info!("Allocation and deallocation of GpuOnly memory was successful.");
     }
@@ -49,7 +59,17 @@ fn main() {
             gpu_allocator::MemoryLocation::CpuToGpu,
         );
         let allocation = allocator.allocate(&allocation_desc).unwrap();
-        let _buffer = allocation.make_buffer().unwrap();
+        // SAFETY: We will only allocate objects on this heap within the returned offset and size
+        let heap = unsafe { allocation.heap() };
+        let buffer = unsafe {
+            heap.newBufferWithLength_options_offset(
+                allocation.size() as usize,
+                heap.resourceOptions(),
+                allocation.offset() as usize,
+            )
+        }
+        .unwrap();
+        drop(buffer);
         allocator.free(&allocation).unwrap();
         info!("Allocation and deallocation of CpuToGpu memory was successful.");
     }
@@ -63,7 +83,17 @@ fn main() {
             gpu_allocator::MemoryLocation::GpuToCpu,
         );
         let allocation = allocator.allocate(&allocation_desc).unwrap();
-        let _buffer = allocation.make_buffer().unwrap();
+        // SAFETY: We will only allocate objects on this heap within the returned offset and size
+        let heap = unsafe { allocation.heap() };
+        let buffer = unsafe {
+            heap.newBufferWithLength_options_offset(
+                allocation.size() as usize,
+                heap.resourceOptions(),
+                allocation.offset() as usize,
+            )
+        }
+        .unwrap();
+        drop(buffer);
         allocator.free(&allocation).unwrap();
         info!("Allocation and deallocation of GpuToCpu memory was successful.");
     }
@@ -78,7 +108,13 @@ fn main() {
         let allocation_desc =
             AllocationCreateDesc::texture(&device, "Test allocation (Texture)", &texture_desc);
         let allocation = allocator.allocate(&allocation_desc).unwrap();
-        let _texture = allocation.make_texture(&texture_desc).unwrap();
+        // SAFETY: We will only allocate objects on this heap within the returned offset and size
+        let heap = unsafe { allocation.heap() };
+        let buffer = unsafe {
+            heap.newTextureWithDescriptor_offset(&texture_desc, allocation.offset() as usize)
+        }
+        .unwrap();
+        drop(buffer);
         allocator.free(&allocation).unwrap();
         info!("Allocation and deallocation of Texture was successful.");
     }
@@ -96,7 +132,16 @@ fn main() {
             gpu_allocator::MemoryLocation::GpuOnly,
         );
         let allocation = allocator.allocate(&allocation_desc).unwrap();
-        let _acc_structure = allocation.make_acceleration_structure();
+        // SAFETY: We will only allocate objects on this heap within the returned offset and size
+        let heap = unsafe { allocation.heap() };
+        let buffer = unsafe {
+            heap.newAccelerationStructureWithSize_offset(
+                allocation.size() as usize,
+                allocation.offset() as usize,
+            )
+        }
+        .unwrap();
+        drop(buffer);
         allocator.free(&allocation).unwrap();
         info!("Allocation and deallocation of Acceleration structure was successful.");
     }

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -335,18 +335,22 @@ impl Allocation {
     }
 
     /// Returns the [`ID3D12Heap`] object that is backing this allocation.
-    /// This heap object can be shared with multiple other allocations and shouldn't be freed (or allocated from)
+    ///
+    /// This heap object can be shared with multiple other allocations and shouldn't be allocated from
     /// without this library, because that will lead to undefined behavior.
     ///
     /// # Safety
-    /// The result of this function be safely passed into [`ID3D12Device::CreatePlacedResource()`].
-    /// It is exposed for this reason. Keep in mind to also pass [`Self::offset()`] along to it.
+    /// The result of this function can safely be passed into [`ID3D12Device::CreatePlacedResource()`].
+    /// It is exposed for this reason.  Keep in mind to also pass [`Self::offset()`] along to it.
+    ///
+    /// Also, this [`Allocation`] must not be [`Allocator::free()`]d while such a created resource
+    /// on this [`ID3D12Heap`] is still live.
     pub unsafe fn heap(&self) -> &ID3D12Heap {
         &self.heap
     }
 
     /// Returns the offset of the allocation on the [`ID3D12Heap`].
-    /// When creating a placed resources, this offset needs to be supplied as well.
+    /// When creating a placed resource, this offset needs to be supplied as well.
     pub fn offset(&self) -> u64 {
         self.offset
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,16 @@
 //!     MemoryLocation::GpuOnly,
 //! );
 //! let allocation = allocator.allocate(&allocation_desc).unwrap();
-//! let resource = allocation.make_buffer().unwrap();
+//! # use objc2_metal::MTLHeap;
+//! let heap = unsafe { allocation.heap() };
+//! let resource = unsafe {
+//!     heap.newBufferWithLength_options_offset(
+//!         allocation.size() as usize,
+//!         heap.resourceOptions(),
+//!         allocation.offset() as usize,
+//!     )
+//! }
+//! .unwrap();
 //!
 //! // Cleanup
 //! drop(resource);

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -39,55 +39,24 @@ pub struct Allocation {
 }
 
 impl Allocation {
-    pub fn heap(&self) -> &ProtocolObject<dyn MTLHeap> {
+    /// Return the backing heap for this allocation
+    pub unsafe fn heap(&self) -> &ProtocolObject<dyn MTLHeap> {
         &self.heap
     }
 
-    pub fn make_buffer(&self) -> Option<Retained<ProtocolObject<dyn MTLBuffer>>> {
-        let resource = unsafe {
-            self.heap.newBufferWithLength_options_offset(
-                self.size as usize,
-                self.heap.resourceOptions(),
-                self.offset as usize,
-            )
-        };
-        if let Some(resource) = &resource {
-            if let Some(name) = &self.name {
-                resource.setLabel(Some(&NSString::from_str(name)));
-            }
-        }
-        resource
+    /// Returns the size of the allocation
+    pub fn size(&self) -> u64 {
+        self.size
     }
 
-    pub fn make_texture(
-        &self,
-        desc: &MTLTextureDescriptor,
-    ) -> Option<Retained<ProtocolObject<dyn MTLTexture>>> {
-        let resource = unsafe {
-            self.heap
-                .newTextureWithDescriptor_offset(desc, self.offset as usize)
-        };
-        if let Some(resource) = &resource {
-            if let Some(name) = &self.name {
-                resource.setLabel(Some(&NSString::from_str(name)));
-            }
-        }
-        resource
+    /// Returns the offset of the allocation on the [`ID3D12Heap`].
+    /// When creating a placed resources, this offset needs to be supplied as well.
+    pub fn offset(&self) -> u64 {
+        self.offset
     }
 
-    pub fn make_acceleration_structure(
-        &self,
-    ) -> Option<Retained<ProtocolObject<dyn MTLAccelerationStructure>>> {
-        let resource = unsafe {
-            self.heap
-                .newAccelerationStructureWithSize_offset(self.size as usize, self.offset as usize)
-        };
-        if let Some(resource) = &resource {
-            if let Some(name) = &self.name {
-                resource.setLabel(Some(&NSString::from_str(name)));
-            }
-        }
-        resource
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_ref().map(|s| s.as_ref())
     }
 
     fn is_null(&self) -> bool {

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -206,13 +206,17 @@ impl Allocation {
     }
 
     /// Returns the [`vk::DeviceMemory`] object that is backing this allocation.
-    /// This memory object can be shared with multiple other allocations and shouldn't be freed (or allocated from)
+    ///
+    /// This memory object can be shared with multiple other allocations and shouldn't be freed or allocated from
     /// without this library, because that will lead to undefined behavior.
     ///
     /// # Safety
-    /// The result of this function can safely be used to pass into [`ash::Device::bind_buffer_memory()`],
-    /// [`ash::Device::bind_image_memory()`] etc. It is exposed for this reason. Keep in mind to also
-    /// pass [`Self::offset()`] along to those.
+    /// The result of this function can safely be passed into [`ash::Device::bind_buffer_memory()`],
+    /// [`ash::Device::bind_image_memory()`] etc. It is exposed for this reason.  Keep in mind to
+    /// also pass [`Self::offset()`] along to those.
+    ///
+    /// Also, this [`Allocation`] must not be [`Allocator::free()`]d while such a created resource
+    /// on this [`vk::DeviceMemory`] is still live.
     pub unsafe fn memory(&self) -> vk::DeviceMemory {
         self.device_memory
     }


### PR DESCRIPTION
These helpers don't really belong in the metal implementation of GPU allocator, instead, they belong in the client APIs using gpu-allocator.

This issue surfaced in our codebase because the `make_acceleration_structure` function didn't pass through all the required information.