### PR TITLE
wrap `Arc<Backtrace>` in Option, saving memory when backtraces are disabled

### DIFF
--- a/src/allocator/dedicated_block_allocator/mod.rs
+++ b/src/allocator/dedicated_block_allocator/mod.rs
@@ -16,7 +16,7 @@ pub(crate) struct DedicatedBlockAllocator {
     allocated: u64,
     /// Only used if [`crate::AllocatorDebugSettings::store_stack_traces`] is [`true`]
     name: Option<String>,
-    backtrace: Arc<Backtrace>,
+    backtrace: Option<Arc<Backtrace>>,
 }
 
 impl DedicatedBlockAllocator {
@@ -25,7 +25,7 @@ impl DedicatedBlockAllocator {
             size,
             allocated: 0,
             name: None,
-            backtrace: Arc::new(Backtrace::disabled()),
+            backtrace: None,
         }
     }
 }
@@ -39,7 +39,7 @@ impl SubAllocator for DedicatedBlockAllocator {
         _allocation_type: AllocationType,
         _granularity: u64,
         name: &str,
-        backtrace: Arc<Backtrace>,
+        backtrace: Option<Arc<Backtrace>>,
     ) -> Result<(u64, std::num::NonZeroU64)> {
         if self.allocated != 0 {
             return Err(AllocationError::OutOfMemory);
@@ -107,6 +107,8 @@ impl SubAllocator for DedicatedBlockAllocator {
             self.size,
             name,
             self.backtrace
+                .as_ref()
+                .map_or(&Backtrace::disabled(), |b| &b)
         )
     }
 

--- a/src/allocator/free_list_allocator/mod.rs
+++ b/src/allocator/free_list_allocator/mod.rs
@@ -32,7 +32,7 @@ pub(crate) struct MemoryChunk {
     pub(crate) allocation_type: AllocationType,
     pub(crate) name: Option<String>,
     /// Only used if [`crate::AllocatorDebugSettings::store_stack_traces`] is [`true`]
-    pub(crate) backtrace: Arc<Backtrace>,
+    pub(crate) backtrace: Option<Arc<Backtrace>>,
     next: Option<std::num::NonZeroU64>,
     prev: Option<std::num::NonZeroU64>,
 }
@@ -79,7 +79,7 @@ impl FreeListAllocator {
                 offset: 0,
                 allocation_type: AllocationType::Free,
                 name: None,
-                backtrace: Arc::new(Backtrace::disabled()),
+                backtrace: None,
                 prev: None,
                 next: None,
             },
@@ -162,7 +162,7 @@ impl SubAllocator for FreeListAllocator {
         allocation_type: AllocationType,
         granularity: u64,
         name: &str,
-        backtrace: Arc<Backtrace>,
+        backtrace: Option<Arc<Backtrace>>,
     ) -> Result<(u64, std::num::NonZeroU64)> {
         let free_size = self.size - self.allocated;
         if size > free_size {
@@ -302,7 +302,7 @@ impl SubAllocator for FreeListAllocator {
             })?;
             chunk.allocation_type = AllocationType::Free;
             chunk.name = None;
-            chunk.backtrace = Arc::new(Backtrace::disabled());
+            chunk.backtrace = None;
 
             self.allocated -= chunk.size;
 
@@ -384,7 +384,7 @@ impl SubAllocator for FreeListAllocator {
                 chunk.offset,
                 chunk.allocation_type,
                 name,
-                chunk.backtrace
+                chunk.backtrace.as_ref().map_or(&Backtrace::disabled(), |b| &b)
             );
         }
     }

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -39,7 +39,7 @@ pub struct AllocationReport {
     /// The size in bytes of the allocation.
     pub size: u64,
     #[cfg(feature = "visualizer")]
-    pub(crate) backtrace: Arc<Backtrace>,
+    pub(crate) backtrace: Option<Arc<Backtrace>>,
 }
 
 /// Describes a memory block in the [`AllocatorReport`].
@@ -113,7 +113,7 @@ pub(crate) trait SubAllocator: SubAllocatorBase + fmt::Debug + Sync + Send {
         allocation_type: AllocationType,
         granularity: u64,
         name: &str,
-        backtrace: Arc<Backtrace>,
+        backtrace: Option<Arc<Backtrace>>,
     ) -> Result<(u64, std::num::NonZeroU64)>;
 
     fn free(&mut self, chunk_id: Option<std::num::NonZeroU64>) -> Result<()>;

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -435,7 +435,7 @@ impl MemoryType {
         &mut self,
         device: &ID3D12DeviceVersion,
         desc: &AllocationCreateDesc<'_>,
-        backtrace: Arc<Backtrace>,
+        backtrace: Option<Arc<Backtrace>>,
         allocation_sizes: &AllocationSizes,
     ) -> Result<Allocation> {
         let allocation_type = AllocationType::Linear;
@@ -731,11 +731,11 @@ impl Allocator {
         let size = desc.size;
         let alignment = desc.alignment;
 
-        let backtrace = Arc::new(if self.debug_settings.store_stack_traces {
-            Backtrace::force_capture()
+        let backtrace = if self.debug_settings.store_stack_traces {
+            Some(Arc::new(Backtrace::force_capture()))
         } else {
-            Backtrace::disabled()
-        });
+            None
+        };
 
         if self.debug_settings.log_allocations {
             debug!(

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -243,7 +243,7 @@ impl MemoryType {
         &mut self,
         device: &ProtocolObject<dyn MTLDevice>,
         desc: &AllocationCreateDesc<'_>,
-        backtrace: Arc<Backtrace>,
+        backtrace: Option<Arc<Backtrace>>,
         allocation_sizes: &AllocationSizes,
     ) -> Result<Allocation> {
         let allocation_type = allocator::AllocationType::Linear;
@@ -473,11 +473,11 @@ impl Allocator {
         let size = desc.size;
         let alignment = desc.alignment;
 
-        let backtrace = Arc::new(if self.debug_settings.store_stack_traces {
-            Backtrace::force_capture()
+        let backtrace = if self.debug_settings.store_stack_traces {
+            Some(Arc::new(Backtrace::force_capture()))
         } else {
-            Backtrace::disabled()
-        });
+            None
+        };
 
         if self.debug_settings.log_allocations {
             debug!(

--- a/src/visualizer/allocation_reports.rs
+++ b/src/visualizer/allocation_reports.rs
@@ -126,10 +126,12 @@ pub(crate) fn render_allocation_reports_ui(
                     ui.label(name);
                 });
 
-                if backtrace.status() == BacktraceStatus::Captured {
-                    resp.1.on_hover_ui(|ui| {
-                        ui.label(backtrace.to_string());
-                    });
+                if let Some(backtrace) = backtrace {
+                    if backtrace.status() == BacktraceStatus::Captured {
+                        resp.1.on_hover_ui(|ui| {
+                            ui.label(backtrace.to_string());
+                        });
+                    }
                 }
 
                 row.col(|ui| {

--- a/src/visualizer/memory_chunks.rs
+++ b/src/visualizer/memory_chunks.rs
@@ -114,10 +114,12 @@ pub(crate) fn render_memory_chunks_ui<'a>(
                             if let Some(name) = &chunk.name {
                                 ui.label(format!("name: {}", name));
                             }
-                            if settings.show_backtraces
-                                && chunk.backtrace.status() == BacktraceStatus::Captured
-                            {
-                                ui.label(chunk.backtrace.to_string());
+                            if settings.show_backtraces {
+                                if let Some(backtrace) = chunk.backtrace.as_ref() {
+                                    if backtrace.status() == BacktraceStatus::Captured {
+                                        ui.label(backtrace.to_string());
+                                    }
+                                }
                             }
                         });
                     }

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -452,7 +452,7 @@ impl MemoryType {
         device: &ash::Device,
         desc: &AllocationCreateDesc<'_>,
         granularity: u64,
-        backtrace: Arc<Backtrace>,
+        backtrace: Option<Arc<Backtrace>>,
         allocation_sizes: &AllocationSizes,
     ) -> Result<Allocation> {
         let allocation_type = if desc.linear {
@@ -768,11 +768,11 @@ impl Allocator {
         let size = desc.requirements.size;
         let alignment = desc.requirements.alignment;
 
-        let backtrace = Arc::new(if self.debug_settings.store_stack_traces {
-            Backtrace::force_capture()
+        let backtrace = if self.debug_settings.store_stack_traces {
+            Some(Arc::new(Backtrace::force_capture()))
         } else {
-            Backtrace::disabled()
-        });
+            None
+        };
 
         if self.debug_settings.log_allocations {
             debug!(


### PR DESCRIPTION
This PR wraps all `Arc<Backtrace>` in Option, as to not have to allocate an Arc of a disabled Backtrace each time GPU memory is allocated with backtraces are disabled. This is probably a premature optimization, but it was so easy to implement I couldn't resist :D