### PR TITLE
Avoid `<=` dependency version specifications that may break builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ presser = { version = "0.3" }
 # such as the ability to link/load a Vulkan library.
 ash = { version = "0.38", optional = true, default-features = false, features = ["debug"] }
 # Only needed for visualizer.
-egui = { version = ">=0.24, <=0.27", optional = true, default-features = false }
-egui_extras = { version = ">=0.24, <=0.27", optional = true, default-features = false }
+egui = { version = ">=0.24, <0.28", optional = true, default-features = false }
+egui_extras = { version = ">=0.24, <0.28", optional = true, default-features = false }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 objc2 = { version = "0.5.2", default-features = false, optional = true }
@@ -51,7 +51,7 @@ objc2-metal = { version = "0.2.1", default-features = false, features = [
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = ">=0.53,<=0.58"
+version = ">=0.53,<0.59"
 features = [
     "Win32_Graphics_Direct3D12",
     "Win32_Graphics_Dxgi_Common",


### PR DESCRIPTION
While updating my dependency on `wgpu`, I noticed that `gpu-allocator` has `<=` version requirements:

```toml
egui = { version = ">=0.24, <=0.27", optional = true, default-features = false }
# ...
[target.'cfg(windows)'.dependencies.windows]
version = ">=0.53,<=0.58"
```

These `<=` version requirements may break builds in the future. In particular, if `egui` releases a version `0.27.1`, or `windows` releases a version `0.58.1`, and another package in the dependency graph requires one of those versions, Cargo will report a fatal error. This is because  `<=0.58` does not mean “less than or equal to any version in `0.58.*`”, it means “less than or equal to 0.58.0” — the third component is implicitly zero — and Cargo will not allow two semver-compatible versions of the same package in the dependency graph.

> Avoid constraining the upper bound of a version to be anything less than the next semver incompatible version (e.g. avoid ">=2.0, <2.4") as other packages in the dependency tree may require a newer version, leading to an unresolvable error (see [#9029](https://github.com/rust-lang/cargo/issues/9029))

— https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-version-requirements

This change avoids this problem by using only `<` requirements.