### PR TITLE
Add support for growing the memory block sizes

### DIFF
--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -440,11 +440,8 @@ impl MemoryType {
     ) -> Result<Allocation> {
         let allocation_type = AllocationType::Linear;
 
-        let memblock_size = if self.heap_properties.Type == D3D12_HEAP_TYPE_DEFAULT {
-            allocation_sizes.device_memblock_size
-        } else {
-            allocation_sizes.host_memblock_size
-        };
+        let is_host = self.heap_properties.Type != D3D12_HEAP_TYPE_DEFAULT;
+        let memblock_size = allocation_sizes.get_memblock_size(is_host, self.active_general_blocks);
 
         let size = desc.size;
         let alignment = desc.alignment;

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -248,11 +248,8 @@ impl MemoryType {
     ) -> Result<Allocation> {
         let allocation_type = allocator::AllocationType::Linear;
 
-        let memblock_size = if self.heap_properties.storageMode() == MTLStorageMode::Private {
-            allocation_sizes.device_memblock_size
-        } else {
-            allocation_sizes.host_memblock_size
-        };
+        let is_host = self.heap_properties.storageMode() != MTLStorageMode::Private;
+        let memblock_size = allocation_sizes.get_memblock_size(is_host, self.active_general_blocks);
 
         let size = desc.size;
         let alignment = desc.alignment;

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -461,14 +461,11 @@ impl MemoryType {
             allocator::AllocationType::NonLinear
         };
 
-        let memblock_size = if self
+        let is_host = self
             .memory_properties
-            .contains(vk::MemoryPropertyFlags::HOST_VISIBLE)
-        {
-            allocation_sizes.host_memblock_size
-        } else {
-            allocation_sizes.device_memblock_size
-        };
+            .contains(vk::MemoryPropertyFlags::HOST_VISIBLE);
+
+        let memblock_size = allocation_sizes.get_memblock_size(is_host, self.active_general_blocks);
 
         let size = desc.requirements.size;
         let alignment = desc.requirements.alignment;
@@ -760,7 +757,7 @@ impl Allocator {
             device: desc.device.clone(),
             buffer_image_granularity: granularity,
             debug_settings: desc.debug_settings,
-            allocation_sizes: AllocationSizes::default(),
+            allocation_sizes: desc.allocation_sizes,
         })
     }
 


### PR DESCRIPTION
Fixes #235.

This PR extends the AllocationsSizes configuration to define ranges of block sizes. The allocators start by allocating blocks with the minimum size and each new allocation for the same memory type doubles the block size.

This allows applications to scale memory usage more organically based on demand. While it is typically not an optimal choice for most games, it allows other types of apps that don't have well defined memory budgets to strike a good tradeoff. My own motivation comes from Firefox's WebGPU implementation. See #235 for more details.

While writing this I found out that the vulkan allocator was not taking the `allocation_size` parameter from its descritptor, so I fixed that along the way.

I, m not sure about how to expose this in the API. In its current state, this PR only adds to the current API and does not change anything for folks who want to stick with the current behavior (fixed block sizes).

Example:

```rust
const MB: u64 = 1024 * 1024;
// This configuration uses fixed memory block sizes.
let fixed = AllocationSizes::new(256 * MB, 64 * MB);
// This configuration starts with 8MB memory blocks
// and grows the block size of a given memory type each
// time a new allocation is needed, up to a limit of
// 256MB for device memory and 64MB for host memory.
let growing = AllocationSizes::new(8 * MB, 8 * MB)
    .with_max_device_memblock_size(256 * MB)
    .with_max_host_memblock_size(64 * MB);
```

 But it looks a bit quirky. One might prefer to simply spell out the ranges when creating `AllocationSizes`. let me know what you prefer.