### PR TITLE
add `Allocation::name` getter

### DIFF
--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -258,6 +258,10 @@ impl Allocation {
     pub fn is_null(&self) -> bool {
         self.chunk_id.is_none()
     }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
 }
 
 impl Default for Allocation {


### PR DESCRIPTION
What the title says, nothing special. I don't want to store yet another copy of the same string, it would be nice if I could just query it instead.