### PR TITLE
cargo: Bump `windows` crate range to `0.53-0.59`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -44,7 +44,6 @@ rustflags = [
     "-Wclippy::match_wild_err_arm",
     "-Wclippy::match_wildcard_for_single_variants",
     "-Wclippy::mem_forget",
-    "-Wclippy::mismatched_target_os",
     "-Wclippy::missing_enforced_import_renames",
     "-Wclippy::mut_mut",
     "-Wclippy::mutex_integer",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Generate lockfile with minimal dependency versions
+        run: cargo +nightly generate-lockfile -Zminimal-versions
       - uses: dtolnay/rust-toolchain@1.70.0
       # Note that examples are extempt from the MSRV check, so that they can use newer Rust features
       - run: cargo check --workspace --features ${{ matrix.features }} --no-default-features
@@ -64,13 +67,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Cargo clippy
         run: cargo clippy --workspace --all-targets --features ${{ matrix.features }} --no-default-features -- -D warnings
-
-      - name: Install nightly Rust
-        uses: dtolnay/rust-toolchain@nightly
-      - name: Generate lockfile with minimal dependency versions
-        run: cargo +nightly generate-lockfile -Zminimal-versions
-      - name: Cargo clippy with minimal-versions
-        run: cargo +stable clippy --workspace --features ${{ matrix.features }} --no-default-features -- -D warnings
 
   doc:
     name: Build documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ objc2-metal = { version = "0.2.1", default-features = false, features = [
 winapi = { version = "0.3.9", features = ["d3d12", "winerror", "impl-default", "impl-debug"], optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = ">=0.53,<=0.58"
+version = ">=0.53,<=0.59"
 features = [
     "Win32_Graphics_Direct3D12",
     "Win32_Graphics_Dxgi_Common",
@@ -68,7 +68,7 @@ winapi = { version = "0.3.9", features = ["d3d12", "d3d12sdklayers", "dxgi1_6", 
 
 [target.'cfg(windows)'.dev-dependencies.windows]
 # API-breaks since Windows 0.58 only affect our examples
-version = "0.58"
+version = ">=0.58,<=0.59"
 features = [
     "Win32_Graphics_Direct3D",
     "Win32_Graphics_Direct3D12",

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -287,7 +287,7 @@ pub struct MappedAllocationSlab<'a> {
 }
 
 // SAFETY: See the safety comment of Allocation::as_mapped_slab above.
-unsafe impl<'a> presser::Slab for MappedAllocationSlab<'a> {
+unsafe impl presser::Slab for MappedAllocationSlab<'_> {
     fn base_ptr(&self) -> *const u8 {
         self.mapped_ptr
     }


### PR DESCRIPTION
https://github.com/microsoft/windows-rs/releases/tag/0.61.0 (tag is strangely on a much higher version...)

Note that `windows 0.59` bumps the MSRV to `1.74`, but we still support this crate dependency all the way back to `0.53`.
