### PR TITLE
🍳 Upgrade to `objc2 0.6` and `objc2-metal 0.3`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 
 jobs:
   check_msrv:
-    name: Check MSRV (1.70.0)
+    name: Check MSRV (1.71.0)
     strategy:
       matrix:
         include:
@@ -20,7 +20,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - name: Generate lockfile with minimal dependency versions
         run: cargo +nightly generate-lockfile -Zminimal-versions
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.71.0
       # Note that examples are extempt from the MSRV check, so that they can use newer Rust features
       - run: cargo check --workspace --features ${{ matrix.features }} --no-default-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/Traverse-Research/gpu-allocator"
 repository = "https://github.com/Traverse-Research/gpu-allocator"
 keywords = ["vulkan", "memory", "allocator"]
 documentation = "https://docs.rs/gpu-allocator/"
-rust-version = "1.70"
+rust-version = "1.71"
 
 include = [
     "/README.md",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,11 @@ egui = { version = ">=0.24, <=0.27", optional = true, default-features = false }
 egui_extras = { version = ">=0.24, <=0.27", optional = true, default-features = false }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-objc2 = { version = "0.5.2", default-features = false, optional = true }
-objc2-foundation = { version = "0.2", default-features = false, optional = true }
-objc2-metal = { version = "0.2.1", default-features = false, features = [
+objc2 = { version = "0.6", default-features = false, optional = true }
+objc2-foundation = { version = "0.3", default-features = false, optional = true }
+objc2-metal = { version = "0.3", default-features = false, features = [
     "MTLAccelerationStructure",
+    "MTLAllocation",
     "MTLBuffer",
     "MTLDevice",
     "MTLHeap",
@@ -76,7 +77,7 @@ features = [
 ]
 
 [target.'cfg(target_vendor = "apple")'.dev-dependencies]
-objc2-metal = { version = "0.2.1", default-features = false, features = [
+objc2-metal = { version = "0.3", default-features = false, features = [
     "MTLPixelFormat",
 ] }
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
 [![LICENSE](https://img.shields.io/badge/license-apache-blue.svg?logo=apache)](LICENSE-APACHE)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](../main/CODE_OF_CONDUCT.md)
-[![MSRV](https://img.shields.io/badge/rustc-1.70.0+-ab6000.svg)](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
+[![MSRV](https://img.shields.io/badge/rustc-1.71.0+-ab6000.svg)](https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html)
 
 [![Banner](banner.png)](https://traverseresearch.nl)
 
@@ -169,7 +169,7 @@ allocator.free(&allocation).unwrap();
 
 ## Minimum Supported Rust Version
 
-The MSRV for this crate and the `vulkan`, `d3d12` and `metal` features is Rust 1.70.  Any other features such as the `visualizer` (with all the `egui` dependencies) may have a higher requirement and are not tested in our CI.
+The MSRV for this crate and the `vulkan`, `d3d12` and `metal` features is Rust 1.71.  Any other features such as the `visualizer` (with all the `egui` dependencies) may have a higher requirement and are not tested in our CI.
 
 ## License
 

--- a/README.tpl
+++ b/README.tpl
@@ -6,7 +6,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
 [![LICENSE](https://img.shields.io/badge/license-apache-blue.svg?logo=apache)](LICENSE-APACHE)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](../main/CODE_OF_CONDUCT.md)
-[![MSRV](https://img.shields.io/badge/rustc-1.70.0+-ab6000.svg)](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
+[![MSRV](https://img.shields.io/badge/rustc-1.71.0+-ab6000.svg)](https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html)
 
 [![Banner](banner.png)](https://traverseresearch.nl)
 
@@ -21,7 +21,7 @@ gpu-allocator = "0.27.0"
 
 ## Minimum Supported Rust Version
 
-The MSRV for this crate and the `vulkan`, `d3d12` and `metal` features is Rust 1.70.  Any other features such as the `visualizer` (with all the `egui` dependencies) may have a higher requirement and are not tested in our CI.
+The MSRV for this crate and the `vulkan`, `d3d12` and `metal` features is Rust 1.71.  Any other features such as the `visualizer` (with all the `egui` dependencies) may have a higher requirement and are not tested in our CI.
 
 ## License
 

--- a/examples/metal-buffer.rs
+++ b/examples/metal-buffer.rs
@@ -1,6 +1,5 @@
 use gpu_allocator::metal::{AllocationCreateDesc, Allocator, AllocatorCreateDesc};
 use log::info;
-use objc2::rc::Id;
 use objc2_foundation::NSArray;
 use objc2_metal::{
     MTLCreateSystemDefaultDevice, MTLDevice as _, MTLHeap, MTLPixelFormat,
@@ -15,8 +14,7 @@ fn main() {
     #[link(name = "CoreGraphics", kind = "framework")]
     extern "C" {}
 
-    let device =
-        unsafe { Id::from_raw(MTLCreateSystemDefaultDevice()) }.expect("No MTLDevice found");
+    let device = MTLCreateSystemDefaultDevice().expect("No MTLDevice found");
 
     // Setting up the allocator
     let mut allocator = Allocator::new(&AllocatorCreateDesc {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,9 +162,7 @@
 //! # #[cfg(feature = "metal")]
 //! # fn main() {
 //! use gpu_allocator::metal::*;
-//! # use objc2::rc::Id;
-//! # let device = unsafe { objc2_metal::MTLCreateSystemDefaultDevice() };
-//! # let device = unsafe { Id::from_raw(device) }.expect("No MTLDevice found");
+//! # let device = objc2_metal::MTLCreateSystemDefaultDevice().expect("No MTLDevice found");
 //! let mut allocator = Allocator::new(&AllocatorCreateDesc {
 //!     device: device.clone(),
 //!     debug_settings: Default::default(),
@@ -181,9 +179,7 @@
 //! # fn main() {
 //! use gpu_allocator::metal::*;
 //! use gpu_allocator::MemoryLocation;
-//! # use objc2::rc::Id;
-//! # let device = unsafe { objc2_metal::MTLCreateSystemDefaultDevice() };
-//! # let device = unsafe { Id::from_raw(device) }.expect("No MTLDevice found");
+//! # let device = objc2_metal::MTLCreateSystemDefaultDevice().expect("No MTLDevice found");
 //! # let mut allocator = Allocator::new(&AllocatorCreateDesc {
 //! #     device: device.clone(),
 //! #     debug_settings: Default::default(),

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -20,9 +20,9 @@ use crate::{
 
 fn memory_location_to_metal(location: MemoryLocation) -> MTLResourceOptions {
     match location {
-        MemoryLocation::GpuOnly => MTLResourceOptions::MTLResourceStorageModePrivate,
+        MemoryLocation::GpuOnly => MTLResourceOptions::StorageModePrivate,
         MemoryLocation::CpuToGpu | MemoryLocation::GpuToCpu | MemoryLocation::Unknown => {
-            MTLResourceOptions::MTLResourceStorageModeShared
+            MTLResourceOptions::StorageModeShared
         }
     }
 }


### PR DESCRIPTION
The `MTLCreateSystemDefaultDevice()` function finally has a high-level wrapper that constructs a `Retained` protocol object for us.

Note also that a new `MTLAllocation` interface was added to Metal.  Even if that interface is _optional_, current `objc2` design requires this trait to be part of the hierarchy (and the feature explicitly enabled) to get access to all "descendant" interfaces (`MTLResource`, which provides `MTLBuffer` and `MTLTexture`). There are upstream plans to see if this can be simplified: https://github.com/madsmtm/objc2/issues/663.