### PR TITLE
d3d12: Include device removal reason when `ERROR_DEVICE_REMOVED` is raised

### DIFF
--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -9,7 +9,10 @@ use std::{
 use log::{debug, warn, Level};
 use windows::Win32::{
     Foundation::E_OUTOFMEMORY,
-    Graphics::{Direct3D12::*, Dxgi::Common::DXGI_FORMAT},
+    Graphics::{
+        Direct3D12::*,
+        Dxgi::{Common::DXGI_FORMAT, DXGI_ERROR_DEVICE_REMOVED},
+    },
 };
 
 #[cfg(feature = "public-winapi")]
@@ -954,6 +957,12 @@ impl Allocator {
                         }
                     }
                 } {
+                    if e.code() == DXGI_ERROR_DEVICE_REMOVED {
+                        return Err(AllocationError::Internal(format!(
+                            "ID3D12Device::CreateCommittedResource DEVICE_REMOVED: {:?}",
+                            unsafe { self.device.GetDeviceRemovedReason() }
+                        )));
+                    }
                     return Err(AllocationError::Internal(format!(
                         "ID3D12Device::CreateCommittedResource failed: {}",
                         e
@@ -1064,6 +1073,12 @@ impl Allocator {
                         }
                     }
                 } {
+                    if e.code() == DXGI_ERROR_DEVICE_REMOVED {
+                        return Err(AllocationError::Internal(format!(
+                            "ID3D12Device::CreatePlacedResource DEVICE_REMOVED: {:?}",
+                            unsafe { self.device.GetDeviceRemovedReason() }
+                        )));
+                    }
                     return Err(AllocationError::Internal(format!(
                         "ID3D12Device::CreatePlacedResource failed: {}",
                         e


### PR DESCRIPTION
Our "painful" `Error::Internal(String)` design for useful errors makes it impossible for downstream crates to retrieve the original `HRESULT` and match on it as necessary to action on stringified error codes like `DXGI_ERROR_DEVICE_REMOVED`, which print:

    ID3D12Device::CreatePlacedResource failed: The GPU device instance has been suspended. Use GetDeviceRemovedReason to determine the appropriate action. (0x887A0005)

Without rearchitecting our `Error` type, the nicest middle ground is anyway for `gpu-allocator` to already add the error message from `GetDeviceRemovedReason()` to the `Result` so that downstream crates can immediately see in their error messages _why_ the device is or was removed/suspended when they make an allocation.
