### PR TITLE
👩‍🏭Update to objc2-metal 0.3 (requires MSRV bump to 1.71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 
 jobs:
   check_msrv:
-    name: Check MSRV (1.70.0)
+    name: Check MSRV (1.71.0)
     strategy:
       matrix:
         include:
@@ -20,7 +20,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - name: Generate lockfile with minimal dependency versions
         run: cargo +nightly generate-lockfile -Zminimal-versions
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.71.0
       # Note that examples are extempt from the MSRV check, so that they can use newer Rust features
       - run: cargo check --workspace --features ${{ matrix.features }} --no-default-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,13 @@ objc2 = { version = "0.5.2", default-features = false, optional = true }
 objc2-foundation = { version = "0.2", default-features = false, optional = true }
 objc2-metal = { version = "0.2.1", default-features = false, features = [
     "MTLAccelerationStructure",
+    "MTLAllocation",
     "MTLBuffer",
     "MTLDevice",
     "MTLHeap",
     "MTLResource",
     "MTLTexture",
+    "MTLHeap",
     "std",
 ], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/Traverse-Research/gpu-allocator"
 repository = "https://github.com/Traverse-Research/gpu-allocator"
 keywords = ["vulkan", "memory", "allocator"]
 documentation = "https://docs.rs/gpu-allocator/"
-rust-version = "1.70"
+rust-version = "1.71"
 
 include = [
     "/README.md",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,9 @@ egui = { version = ">=0.24, <=0.27", optional = true, default-features = false }
 egui_extras = { version = ">=0.24, <=0.27", optional = true, default-features = false }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-objc2 = { version = "0.5.2", default-features = false, optional = true }
-objc2-foundation = { version = "0.2", default-features = false, optional = true }
-objc2-metal = { version = "0.2.1", default-features = false, features = [
+objc2 = { version = "0.6", default-features = false, features = ["std"], optional = true }
+objc2-foundation = { version = "0.3", default-features = false, features = ["std"], optional = true }
+objc2-metal = { version = "0.3", default-features = false, features = [
     "MTLAccelerationStructure",
     "MTLAllocation",
     "MTLBuffer",
@@ -78,7 +78,7 @@ features = [
 ]
 
 [target.'cfg(target_vendor = "apple")'.dev-dependencies]
-objc2-metal = { version = "0.2.1", default-features = false, features = [
+objc2-metal = { version = "0.3", default-features = false, features = [
     "MTLPixelFormat",
 ] }
 

--- a/examples/metal-buffer.rs
+++ b/examples/metal-buffer.rs
@@ -1,9 +1,9 @@
 use gpu_allocator::metal::{AllocationCreateDesc, Allocator, AllocatorCreateDesc};
 use log::info;
-use objc2::rc::Id;
+use objc2::{rc::Retained, runtime::ProtocolObject};
 use objc2_foundation::NSArray;
 use objc2_metal::{
-    MTLCreateSystemDefaultDevice, MTLDevice as _, MTLHeap, MTLPixelFormat,
+    MTLCreateSystemDefaultDevice, MTLDevice, MTLHeap, MTLPixelFormat,
     MTLPrimitiveAccelerationStructureDescriptor, MTLStorageMode, MTLTextureDescriptor,
 };
 
@@ -15,8 +15,8 @@ fn main() {
     #[link(name = "CoreGraphics", kind = "framework")]
     extern "C" {}
 
-    let device =
-        unsafe { Id::from_raw(MTLCreateSystemDefaultDevice()) }.expect("No MTLDevice found");
+    let device: Retained<ProtocolObject<dyn MTLDevice>> =
+        MTLCreateSystemDefaultDevice().expect("No MTLDevice found");
 
     // Setting up the allocator
     let mut allocator = Allocator::new(&AllocatorCreateDesc {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,9 +162,7 @@
 //! # #[cfg(feature = "metal")]
 //! # fn main() {
 //! use gpu_allocator::metal::*;
-//! # use objc2::rc::Id;
-//! # let device = unsafe { objc2_metal::MTLCreateSystemDefaultDevice() };
-//! # let device = unsafe { Id::from_raw(device) }.expect("No MTLDevice found");
+//! # let device = objc2_metal::MTLCreateSystemDefaultDevice().expect("No MTLDevice found");
 //! let mut allocator = Allocator::new(&AllocatorCreateDesc {
 //!     device: device.clone(),
 //!     debug_settings: Default::default(),
@@ -181,9 +179,7 @@
 //! # fn main() {
 //! use gpu_allocator::metal::*;
 //! use gpu_allocator::MemoryLocation;
-//! # use objc2::rc::Id;
-//! # let device = unsafe { objc2_metal::MTLCreateSystemDefaultDevice() };
-//! # let device = unsafe { Id::from_raw(device) }.expect("No MTLDevice found");
+//! # let device = objc2_metal::MTLCreateSystemDefaultDevice().expect("No MTLDevice found");
 //! # let mut allocator = Allocator::new(&AllocatorCreateDesc {
 //! #     device: device.clone(),
 //! #     debug_settings: Default::default(),

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -20,9 +20,9 @@ use crate::{
 
 fn memory_location_to_metal(location: MemoryLocation) -> MTLResourceOptions {
     match location {
-        MemoryLocation::GpuOnly => MTLResourceOptions::MTLResourceStorageModePrivate,
+        MemoryLocation::GpuOnly => MTLResourceOptions::StorageModePrivate,
         MemoryLocation::CpuToGpu | MemoryLocation::GpuToCpu | MemoryLocation::Unknown => {
-            MTLResourceOptions::MTLResourceStorageModeShared
+            MTLResourceOptions::StorageModeShared
         }
     }
 }


### PR DESCRIPTION
We need this as a dependency going forward instead; and this requires some minor changes.

https://docs.rs/objc2-metal/latest/objc2_metal/trait.MTLHeap.html

Notice: this requires an MSRV bump for objc2.