### PR TITLE
Add reserved_bytes method for Allocator

### DIFF
--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -61,8 +61,8 @@ pub struct AllocatorReport {
     pub blocks: Vec<MemoryBlockReport>,
     /// Sum of the memory used by all allocations, in bytes.
     pub total_allocated_bytes: u64,
-    /// Sum of the memory reserved by all memory blocks including unallocated regions, in bytes.
-    pub total_reserved_bytes: u64,
+    /// Sum of the memory capacity of all memory blocks including unallocated regions, in bytes.
+    pub total_capacity_bytes: u64,
 }
 
 impl fmt::Debug for AllocationReport {
@@ -90,7 +90,7 @@ impl fmt::Debug for AllocatorReport {
                 &std::format_args!(
                     "{} / {}",
                     fmt_bytes(self.total_allocated_bytes),
-                    fmt_bytes(self.total_reserved_bytes)
+                    fmt_bytes(self.total_capacity_bytes)
                 ),
             )
             .field("blocks", &self.blocks.len())

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -1149,6 +1149,19 @@ impl Allocator {
             total_capacity_bytes,
         }
     }
+
+    /// Current total capacity of memory blocks allocated on the device, in bytes
+    pub fn capacity(&self) -> u64 {
+        let mut total_capacity_bytes = 0;
+
+        for memory_type in &self.memory_types {
+            for block in memory_type.memory_blocks.iter().flatten() {
+                total_capacity_bytes += block.size;
+            }
+        }
+
+        total_capacity_bytes
+    }
 }
 
 impl fmt::Debug for Allocator {

--- a/src/d3d12/mod.rs
+++ b/src/d3d12/mod.rs
@@ -1126,11 +1126,11 @@ impl Allocator {
     pub fn generate_report(&self) -> AllocatorReport {
         let mut allocations = vec![];
         let mut blocks = vec![];
-        let mut total_reserved_bytes = 0;
+        let mut total_capacity_bytes = 0;
 
         for memory_type in &self.memory_types {
             for block in memory_type.memory_blocks.iter().flatten() {
-                total_reserved_bytes += block.size;
+                total_capacity_bytes += block.size;
                 let first_allocation = allocations.len();
                 allocations.extend(block.sub_allocator.report_allocations());
                 blocks.push(MemoryBlockReport {
@@ -1146,7 +1146,7 @@ impl Allocator {
             allocations,
             blocks,
             total_allocated_bytes,
-            total_reserved_bytes,
+            total_capacity_bytes,
         }
     }
 }

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -541,4 +541,17 @@ impl Allocator {
             total_capacity_bytes,
         }
     }
+
+    /// Current total capacity of memory blocks allocated on the device, in bytes
+    pub fn capacity(&self) -> u64 {
+        let mut total_capacity_bytes = 0;
+
+        for memory_type in &self.memory_types {
+            for block in memory_type.memory_blocks.iter().flatten() {
+                total_capacity_bytes += block.size;
+            }
+        }
+
+        total_capacity_bytes
+    }
 }

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -518,11 +518,11 @@ impl Allocator {
     pub fn generate_report(&self) -> AllocatorReport {
         let mut allocations = vec![];
         let mut blocks = vec![];
-        let mut total_reserved_bytes = 0;
+        let mut total_capacity_bytes = 0;
 
         for memory_type in &self.memory_types {
             for block in memory_type.memory_blocks.iter().flatten() {
-                total_reserved_bytes += block.size;
+                total_capacity_bytes += block.size;
                 let first_allocation = allocations.len();
                 allocations.extend(block.sub_allocator.report_allocations());
                 blocks.push(MemoryBlockReport {
@@ -538,7 +538,7 @@ impl Allocator {
             allocations,
             blocks,
             total_allocated_bytes,
-            total_reserved_bytes,
+            total_capacity_bytes,
         }
     }
 }

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -957,6 +957,19 @@ impl Allocator {
             total_capacity_bytes,
         }
     }
+
+    /// Current total capacity of memory blocks allocated on the device, in bytes
+    pub fn capacity(&self) -> u64 {
+        let mut total_capacity_bytes = 0;
+
+        for memory_type in &self.memory_types {
+            for block in memory_type.memory_blocks.iter().flatten() {
+                total_capacity_bytes += block.size;
+            }
+        }
+
+        total_capacity_bytes
+    }
 }
 
 impl Drop for Allocator {

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -934,11 +934,11 @@ impl Allocator {
     pub fn generate_report(&self) -> AllocatorReport {
         let mut allocations = vec![];
         let mut blocks = vec![];
-        let mut total_reserved_bytes = 0;
+        let mut total_capacity_bytes = 0;
 
         for memory_type in &self.memory_types {
             for block in memory_type.memory_blocks.iter().flatten() {
-                total_reserved_bytes += block.size;
+                total_capacity_bytes += block.size;
                 let first_allocation = allocations.len();
                 allocations.extend(block.sub_allocator.report_allocations());
                 blocks.push(MemoryBlockReport {
@@ -954,7 +954,7 @@ impl Allocator {
             allocations,
             blocks,
             total_allocated_bytes,
-            total_reserved_bytes,
+            total_capacity_bytes,
         }
     }
 }


### PR DESCRIPTION
This fills the use case where one needs the total number of reserved bytes from an Allocator, but compiling a complete report (in particular due to the calls to report_allocations from the SubAllocator) would be too costly.

I've encountered this in a (not yet open) project of mine and would be happy if you would accept this contribution. My workaround of just counting the allocation size myself underestimates the total allocated memory due to fragmentation.