### PR TITLE
metal: Create a global residency set, holding all allocated heaps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ objc2-metal = { version = "0.3", default-features = false, features = [
     "MTLBuffer",
     "MTLDevice",
     "MTLHeap",
+    "MTLResidencySet",
     "MTLResource",
     "MTLTexture",
     "std",

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ let mut allocator = Allocator::new(&AllocatorCreateDesc {
     device: device.clone(),
     debug_settings: Default::default(),
     allocation_sizes: Default::default(),
+    create_residency_set: false,
 });
 ```
 

--- a/examples/metal-buffer.rs
+++ b/examples/metal-buffer.rs
@@ -21,6 +21,7 @@ fn main() {
         device: device.clone(),
         debug_settings: Default::default(),
         allocation_sizes: Default::default(),
+        create_residency_set: false,
     })
     .unwrap();
 

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -133,6 +133,8 @@ pub(crate) trait SubAllocator: SubAllocatorBase + fmt::Debug + Sync + Send {
 
     fn report_allocations(&self) -> Vec<AllocationReport>;
 
+    /// Returns [`true`] if this allocator allows sub-allocating multiple allocations, [`false`] if
+    /// it is designed to only represent dedicated allocations.
     #[must_use]
     fn supports_general_allocations(&self) -> bool;
     #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,7 @@
 //!     device: device.clone(),
 //!     debug_settings: Default::default(),
 //!     allocation_sizes: Default::default(),
+//!     create_residency_set: false,
 //! });
 //! # }
 //! # #[cfg(not(feature = "metal"))]
@@ -177,6 +178,7 @@
 //! #     device: device.clone(),
 //! #     debug_settings: Default::default(),
 //! #     allocation_sizes: Default::default(),
+//! #    create_residency_set: false,
 //! # })
 //! # .unwrap();
 //! let allocation_desc = AllocationCreateDesc::buffer(

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -657,24 +657,22 @@ impl MemoryType {
 
         mem_block.sub_allocator.free(allocation.chunk_id)?;
 
-        if mem_block.sub_allocator.is_empty() {
-            if mem_block.sub_allocator.supports_general_allocations() {
-                if self.active_general_blocks > 1 {
-                    let block = self.memory_blocks[block_idx].take();
-                    let block = block.ok_or_else(|| {
-                        AllocationError::Internal("Memory block must be Some.".into())
-                    })?;
-                    block.destroy(device);
+        // We only want to destroy this now-empty block if it is either a dedicated/personal
+        // allocation, or a block supporting sub-allocations that is not the last one (ensuring
+        // there's always at least one block/allocator readily available).
+        let is_dedicated_or_not_last_general_block =
+            !mem_block.sub_allocator.supports_general_allocations()
+                || self.active_general_blocks > 1;
+        if mem_block.sub_allocator.is_empty() && is_dedicated_or_not_last_general_block {
+            let block = self.memory_blocks[block_idx]
+                .take()
+                .ok_or_else(|| AllocationError::Internal("Memory block must be Some.".into()))?;
 
-                    self.active_general_blocks -= 1;
-                }
-            } else {
-                let block = self.memory_blocks[block_idx].take();
-                let block = block.ok_or_else(|| {
-                    AllocationError::Internal("Memory block must be Some.".into())
-                })?;
-                block.destroy(device);
+            if block.sub_allocator.supports_general_allocations() {
+                self.active_general_blocks -= 1;
             }
+
+            block.destroy(device);
         }
 
         Ok(())


### PR DESCRIPTION
`gpu-allocator` creates heaps on which callers can allocate ranges and create "placed" resources like textures, buffers and acceleration structures.  These individual resources, or the heaps as a whole, need to be made resident on the command buffer or even globally on an entire queue.

In the previous API those heaps had to be made resident on individual command *encoders* with `useHeap(s):` (making an entire heap resident perfectly matches a bindless design, as opposed to making every individual resource -either placed on the heap or allocated separately-
resident with `useResource(s):`).  Worse, this API only applies `MTLResourceUsageRead` (exluding `RenderTarget` and `ShaderWrite` textures) which would disallow any resources on the heap to be written.

Now with `MTLResidencySet` multiple heaps can be made resident with one call, defeating the performance overhead of individually "using" all heaps on *every* command *encoder*.  But without tracking this inside `gpu-allocator`, users of our crate still have to manually rebuild this `MTLResidencySet` each time they change their allocations, without knowing when `gpu-allocator` created or destroyed a heap.

By managing a single updated `MTLResidencySet` in `gpu-allocator`, callers can simply call `.commit()` on this object right before they submit command buffers referencing resources on these heaps, as long as they have the residency set attached to the queue in question or "used" on the command buffer that is being submitted.  This removes all the performance overhead of repeatedly creating `MTLResidencySet`s, which otherwise defeats the purpose of it over plain `useHeap(s):` call(s).
