### PR TITLE
Add external memory support for vulkan on windows & linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ let mut allocator = Allocator::new(&AllocatorCreateDesc {
     debug_settings: Default::default(),
     buffer_device_address: true,  // Ideally, check the BufferDeviceAddressFeatures struct.
     allocation_sizes: Default::default(),
+    external_memory: false,
 });
 ```
 
@@ -55,6 +56,7 @@ let allocation = allocator
         location: MemoryLocation::CpuToGpu,
         linear: true, // Buffers are always linear
         allocation_scheme: AllocationScheme::GpuAllocatorManaged,
+        external_use: false,
     }).unwrap();
 
 // Bind memory to the buffer

--- a/examples/vulkan-buffer.rs
+++ b/examples/vulkan-buffer.rs
@@ -90,6 +90,7 @@ fn main() {
         debug_settings: Default::default(),
         buffer_device_address: false,
         allocation_sizes: Default::default(),
+        external_memory: false,
     })
     .unwrap();
 
@@ -110,6 +111,7 @@ fn main() {
                 linear: true,
                 allocation_scheme: AllocationScheme::GpuAllocatorManaged,
                 name: "Test allocation (Gpu Only)",
+                external_use: false,
             })
             .unwrap();
 
@@ -143,6 +145,7 @@ fn main() {
                 linear: true,
                 allocation_scheme: AllocationScheme::GpuAllocatorManaged,
                 name: "Test allocation (Cpu to Gpu)",
+                external_use: false,
             })
             .unwrap();
 
@@ -176,6 +179,7 @@ fn main() {
                 linear: true,
                 allocation_scheme: AllocationScheme::GpuAllocatorManaged,
                 name: "Test allocation (Gpu to Cpu)",
+                external_use: false,
             })
             .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 //!     debug_settings: Default::default(),
 //!     buffer_device_address: true,  // Ideally, check the BufferDeviceAddressFeatures struct.
 //!     allocation_sizes: Default::default(),
+//!     external_memory: false,
 //! });
 //! # }
 //! # #[cfg(not(feature = "vulkan"))]
@@ -42,6 +43,7 @@
 //! #     debug_settings: Default::default(),
 //! #     buffer_device_address: true,  // Ideally, check the BufferDeviceAddressFeatures struct.
 //! #     allocation_sizes: Default::default(),
+//! #     external_memory: false,
 //! # }).unwrap();
 //!
 //! // Setup vulkan info
@@ -59,6 +61,7 @@
 //!         location: MemoryLocation::CpuToGpu,
 //!         linear: true, // Buffers are always linear
 //!         allocation_scheme: AllocationScheme::GpuAllocatorManaged,
+//!         external_use: false,
 //!     }).unwrap();
 //!
 //! // Bind memory to the buffer

--- a/src/result.rs
+++ b/src/result.rs
@@ -20,6 +20,9 @@ pub enum AllocationError {
     CastableFormatsRequiresEnhancedBarriers,
     #[error("Castable formats require at least `Device12`")]
     CastableFormatsRequiresAtLeastDevice12,
+
+    #[error("Allocating exportable memory requires the allocator be created with external memory support")]
+    ExternalMemoryUnsupported,
 }
 
 pub type Result<V, E = AllocationError> = ::std::result::Result<V, E>;

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -392,12 +392,12 @@ impl MemoryBlock {
             };
 
             // On other platforms you can't create an external capable allocator, so this would be unreachable
-            #[cfg(any(windows, all(unix, not(target_vendor = "apple"))))]
-            let alloc_info = if desc.exportable {
-                alloc_info.push_next(&mut export_info)
-            } else {
-                alloc_info
-            };
+            let alloc_info =
+                if cfg!(any(windows, all(unix, not(target_vendor = "apple")))) && desc.exportable {
+                    alloc_info.push_next(&mut export_info)
+                } else {
+                    alloc_info
+                };
 
             // Flag the memory as dedicated if required.
             let mut dedicated_memory_info = vk::MemoryDedicatedAllocateInfo::default();

--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -381,12 +381,15 @@ impl MemoryBlock {
             } else {
                 alloc_info
             };
-            #[cfg(windows)]
-            let mut export_info = vk::ExportMemoryAllocateInfoKHR::default()
-                .handle_types(vk::ExternalMemoryHandleTypeFlags::OPAQUE_WIN32_KHR);
-            #[cfg(all(unix, not(target_vendor = "apple")))]
-            let mut export_info = vk::ExportMemoryAllocateInfoKHR::default()
-                .handle_types(vk::ExternalMemoryHandleTypeFlags::OPAQUE_FD_KHR);
+            let mut export_info = if cfg!(windows) {
+                vk::ExportMemoryAllocateInfoKHR::default()
+                    .handle_types(vk::ExternalMemoryHandleTypeFlags::OPAQUE_WIN32_KHR)
+            } else if cfg!(all(unix, not(target_vendor = "apple"))) {
+                vk::ExportMemoryAllocateInfoKHR::default()
+                    .handle_types(vk::ExternalMemoryHandleTypeFlags::OPAQUE_FD_KHR)
+            } else {
+                vk::ExportMemoryAllocateInfoKHR::default()
+            };
 
             // On other platforms you can't create an external capable allocator, so this would be unreachable
             #[cfg(any(windows, all(unix, not(target_vendor = "apple"))))]


### PR DESCRIPTION
This has been tested by my own project, though no in tree testing is there yet(not sure how I'd add that). Also, the testing is only for vulkan Linux but I suspect it would also work on Windows in its current state.

Based on discussion in #274, also going to ping @Jasper-Bekkers :)

Implementation details: the memory is only allocated with support for exporting it later. The user must manually export the memory later, though this isn't very difficult. Used as a reference was [this article from vulkan docs](https://docs.vulkan.org/guide/latest/extensions/external.html).