### PR TITLE
vulkan: add getter for Allocation::memory_type_index

### DIFF
--- a/src/vulkan/mod.rs
+++ b/src/vulkan/mod.rs
@@ -208,6 +208,15 @@ impl Allocation {
         self.chunk_id
     }
 
+    /// Returns the index into the `memory_types` array of
+    /// `vk::PhysicalDeviceMemoryProperties` of the memory type that this
+    /// allocation is using.
+    /// This can be useful when trying to bind this allocation to a resource
+    /// with specific memory requirements.
+    pub fn memory_type_index(&self) -> usize {
+        self.memory_type_index
+    }
+
     ///Returns the [`vk::MemoryPropertyFlags`] of this allocation.
     pub fn memory_properties(&self) -> vk::MemoryPropertyFlags {
         self.memory_properties


### PR DESCRIPTION
When reusing allocations for aliasing or rebinding it's useful to know that the memory type of the allocation is actually compatible with the memory requirements of the resource-to-bind, and since the allocation internally carries this information I think it makes sense to expose it.

I haven't looked at whether or not this is something that should be done for dx12 and metal as well since I'm not very familiar with those APIs.